### PR TITLE
fix: strip thinking blocks from JSONL before model-switch resume

### DIFF
--- a/src-tauri/src/commands/claude_process.rs
+++ b/src-tauri/src/commands/claude_process.rs
@@ -164,4 +164,8 @@ pub struct StartSessionParams {
     /// When not "bypassPermissions", enables --permission-prompt-tool stdio for structured
     /// permission requests via the SDK control protocol.
     pub permission_mode: Option<String>,
+    /// When true and resume_session_id is set, strip thinking blocks from the session JSONL
+    /// before resuming. This prevents "invalid thinking signature" 400 errors when switching
+    /// to a different model that can't verify the old model's cryptographic signatures.
+    pub model_switch: Option<bool>,
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1055,6 +1055,188 @@ fn resolve_provider_env(
     Ok((env, keys_to_remove, extra_args))
 }
 
+/// Find the JSONL file for a given session UUID by scanning ~/.claude/projects/*/.
+/// Returns the path if found, None otherwise.
+/// Validates that session_id looks like a UUID to prevent path traversal.
+fn find_session_jsonl(session_id: &str) -> Option<std::path::PathBuf> {
+    // Reject non-UUID session IDs to prevent path traversal (e.g. "../../../etc/passwd")
+    if uuid::Uuid::parse_str(session_id).is_err() {
+        eprintln!("[TOKENICODE] find_session_jsonl: rejecting non-UUID session_id: {}", session_id);
+        return None;
+    }
+
+    let home = dirs::home_dir()?;
+    let claude_projects = home.join(".claude").join("projects");
+    if !claude_projects.exists() {
+        return None;
+    }
+
+    let target_filename = format!("{}.jsonl", session_id);
+    if let Ok(entries) = std::fs::read_dir(&claude_projects) {
+        for entry in entries.flatten() {
+            if entry.path().is_dir() {
+                let candidate = entry.path().join(&target_filename);
+                if candidate.exists() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Strip thinking and redacted_thinking blocks from a session's JSONL file.
+/// This is used before resuming a session with a different model, because the
+/// new model cannot verify the old model's cryptographic thinking signatures
+/// and will reject the request with a 400 error.
+///
+/// Returns Ok(blocks_stripped) on success, or Err with a description on failure.
+/// The caller should NOT block the session resume on failure — let the auto-retry
+/// path handle it as a safety net.
+fn strip_thinking_blocks_from_session(session_id: &str) -> Result<usize, String> {
+    use std::io::{BufRead, Write};
+
+    let jsonl_path = find_session_jsonl(session_id)
+        .ok_or_else(|| format!("Session JSONL not found for id: {}", session_id))?;
+
+    eprintln!(
+        "[TOKENICODE] strip_thinking_blocks: processing {:?}",
+        jsonl_path
+    );
+
+    // Read all lines
+    let file = std::fs::File::open(&jsonl_path)
+        .map_err(|e| format!("Failed to open JSONL: {}", e))?;
+    let reader = std::io::BufReader::new(file);
+    let lines: Vec<String> = reader
+        .lines()
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("Failed to read JSONL: {}", e))?;
+
+    let mut total_stripped = 0usize;
+    let mut modified_lines = Vec::with_capacity(lines.len());
+
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            modified_lines.push(line);
+            continue;
+        }
+
+        match serde_json::from_str::<serde_json::Value>(trimmed) {
+            Ok(mut json_line) => {
+                // Look for assistant messages with content arrays.
+                // Format: {"type":"assistant","message":{"role":"assistant","content":[...]}}
+                // Thinking blocks only appear at this level — tool_result content arrays
+                // contain tool output, not model thinking.
+                if let Some(stripped) = strip_thinking_from_value(&mut json_line) {
+                    total_stripped += stripped;
+                }
+                modified_lines.push(serde_json::to_string(&json_line).unwrap_or(line));
+            }
+            Err(_) => {
+                // Not valid JSON — keep the line as-is
+                modified_lines.push(line);
+            }
+        }
+    }
+
+    if total_stripped > 0 {
+        // Backup the original file before overwriting
+        let backup_path = jsonl_path.with_extension("jsonl.bak");
+        if let Err(e) = std::fs::copy(&jsonl_path, &backup_path) {
+            eprintln!(
+                "[TOKENICODE] strip_thinking_blocks: backup failed ({}) — proceeding anyway",
+                e
+            );
+        }
+
+        // Write the cleaned JSONL via temp file + platform-specific replace.
+        let tmp_path = jsonl_path.with_extension("jsonl.tmp");
+        let mut tmp_file = std::fs::File::create(&tmp_path)
+            .map_err(|e| format!("Failed to create temp file: {}", e))?;
+        for line in &modified_lines {
+            writeln!(tmp_file, "{}", line)
+                .map_err(|e| format!("Failed to write temp file: {}", e))?;
+        }
+        tmp_file
+            .flush()
+            .map_err(|e| format!("Failed to flush temp file: {}", e))?;
+        // Drop the file handle before rename — on Windows, an open handle
+        // can prevent rename from succeeding.
+        drop(tmp_file);
+
+        // On Unix, rename() atomically replaces the target — no data loss window.
+        // On Windows, rename() cannot overwrite an existing file, so we use a
+        // two-step approach with rollback from backup on failure.
+        #[cfg(not(target_os = "windows"))]
+        {
+            std::fs::rename(&tmp_path, &jsonl_path)
+                .map_err(|e| format!("Failed to rename temp file: {}", e))?;
+        }
+        #[cfg(target_os = "windows")]
+        {
+            let replace_result = (|| -> std::io::Result<()> {
+                // Try std::fs::rename first — works if target doesn't exist
+                if std::fs::rename(&tmp_path, &jsonl_path).is_ok() {
+                    return Ok(());
+                }
+                // Fallback: backup old file, rename new, rollback on failure
+                let win_backup = jsonl_path.with_extension("jsonl.wbak");
+                let _ = std::fs::remove_file(&win_backup);
+                std::fs::rename(&jsonl_path, &win_backup)?;
+                if let Err(e) = std::fs::rename(&tmp_path, &jsonl_path) {
+                    // Rollback: restore original file
+                    let _ = std::fs::rename(&win_backup, &jsonl_path);
+                    return Err(e);
+                }
+                let _ = std::fs::remove_file(&win_backup);
+                Ok(())
+            })();
+            replace_result.map_err(|e| format!("Failed to replace JSONL on Windows: {}", e))?;
+        }
+
+        eprintln!(
+            "[TOKENICODE] strip_thinking_blocks: stripped {} thinking blocks from {:?}",
+            total_stripped, jsonl_path
+        );
+    } else {
+        eprintln!(
+            "[TOKENICODE] strip_thinking_blocks: no thinking blocks found in {:?}",
+            jsonl_path
+        );
+    }
+
+    Ok(total_stripped)
+}
+
+/// Strip thinking/redacted_thinking content blocks from a JSON value's message.content array.
+/// Returns the number of blocks stripped, or None if nothing was modified.
+fn strip_thinking_from_value(value: &mut serde_json::Value) -> Option<usize> {
+    let mut stripped = 0usize;
+
+    // Look for message.content array (assistant messages)
+    if let Some(message) = value.get_mut("message") {
+        if let Some(content) = message.get_mut("content") {
+            if let Some(arr) = content.as_array_mut() {
+                let before_len = arr.len();
+                arr.retain(|item| {
+                    item.get("type")
+                        .and_then(|t| t.as_str())
+                        .map_or(true, |t| t != "thinking" && t != "redacted_thinking")
+                });
+                stripped += before_len - arr.len();
+            }
+        }
+    }
+
+    if stripped > 0 {
+        Some(stripped)
+    } else {
+        None
+    }
+}
+
 #[tauri::command]
 async fn start_claude_session(
     app: AppHandle,
@@ -1085,6 +1267,21 @@ async fn start_claude_session(
         // overhead as each must initialize before the CLI accepts input.
         "--strict-mcp-config".to_string(),
     ];
+
+    // Model switch: strip thinking blocks from the session JSONL before resuming.
+    // When switching models, the old model's cryptographic thinking signatures in the
+    // JSONL cause the new model to reject the request (400 error). Stripping them
+    // preserves the conversation text while removing the invalid signatures.
+    // This is best-effort: failure is logged but does NOT block the resume attempt.
+    // The auto-retry path in useStreamProcessor.ts will catch any remaining errors.
+    if params.model_switch.unwrap_or(false) {
+        if let Some(ref resume_id) = params.resume_session_id {
+            match strip_thinking_blocks_from_session(resume_id) {
+                Ok(n) => eprintln!("[TOKENICODE] model_switch: stripped {} thinking blocks before resume", n),
+                Err(e) => eprintln!("[TOKENICODE] model_switch: thinking-block strip failed ({}), attempting resume anyway", e),
+            }
+        }
+    }
 
     // Resume an existing CLI session if requested
     if let Some(ref resume_id) = params.resume_session_id {
@@ -6568,5 +6765,93 @@ mod decode_tests {
         println!("Result: {}", result);
         // Should decode to "/Users/tinyzhuang/Desktop/jd 设计"
         assert_eq!(result, "/Users/tinyzhuang/Desktop/jd 设计");
+    }
+}
+
+#[cfg(test)]
+mod strip_thinking_tests {
+    use super::strip_thinking_from_value;
+    use serde_json::json;
+
+    #[test]
+    fn test_strip_thinking_removes_thinking_blocks() {
+        let mut value = json!({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "private thoughts"},
+                    {"type": "text", "text": "Hello!"},
+                    {"type": "redacted_thinking", "data": "opaque"},
+                ]
+            }
+        });
+        let stripped = strip_thinking_from_value(&mut value);
+        assert_eq!(stripped, Some(2));
+        let content = value["message"]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "text");
+    }
+
+    #[test]
+    fn test_strip_thinking_preserves_other_types() {
+        let mut value = json!({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Hello!"},
+                    {"type": "tool_use", "id": "t1", "name": "bash"},
+                    {"type": "tool_result", "tool_use_id": "t1", "content": "output"},
+                ]
+            }
+        });
+        let stripped = strip_thinking_from_value(&mut value);
+        assert_eq!(stripped, None);
+        assert_eq!(value["message"]["content"].as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn test_strip_thinking_user_message_unchanged() {
+        let mut value = json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": "What is 2+2?"
+            }
+        });
+        let stripped = strip_thinking_from_value(&mut value);
+        assert_eq!(stripped, None);
+    }
+
+    #[test]
+    fn test_strip_thinking_empty_content() {
+        let mut value = json!({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": []
+            }
+        });
+        let stripped = strip_thinking_from_value(&mut value);
+        assert_eq!(stripped, None);
+    }
+
+    #[test]
+    fn test_strip_thinking_only_thinking_blocks() {
+        // Edge case: all blocks are thinking — result is empty content array
+        let mut value = json!({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "hmm"},
+                    {"type": "redacted_thinking", "data": "abc"},
+                ]
+            }
+        });
+        let stripped = strip_thinking_from_value(&mut value);
+        assert_eq!(stripped, Some(2));
+        assert_eq!(value["message"]["content"].as_array().unwrap().len(), 0);
     }
 }

--- a/src/components/chat/InputBar.tsx
+++ b/src/components/chat/InputBar.tsx
@@ -858,6 +858,18 @@ export function InputBar() {
           // If the resume fails due to thinking signature mismatch, the
           // stream error handler will auto-retry without resume.
           setSessionMeta(tabId, { stdinId: undefined, envFingerprint: undefined, providerSwitched: true, providerSwitchPendingText: text });
+          // Clean thinking blocks from history to avoid signature mismatch on resume.
+          // Provider change likely routes to a different backend that can't verify
+          // the old model's thinking signatures.
+          useChatStore.setState((state) => {
+            const tab = state.tabs.get(tabId);
+            if (!tab) return {};
+            const cleanedMessages = tab.messages.filter(m => m.type !== 'thinking');
+            if (cleanedMessages.length === tab.messages.length) return {};
+            const newTabs = new Map(state.tabs);
+            newTabs.set(tabId, { ...tab, messages: cleanedMessages });
+            return { tabs: newTabs, sessionCache: newTabs };
+          });
           stdinId = undefined;
         } else {
           // Check if model changed since this process was spawned.
@@ -1059,7 +1071,8 @@ export function InputBar() {
         // Read sessionMode from store (not closure) so plan-approve → code
         // mode switch is visible even when called via rAF.
         const liveSessionMode = useSettingsStore.getState().sessionMode;
-        console.log('[TOKENICODE:session] starting session', { cwd, stdinId: preGeneratedId, mode: liveSessionMode, provider: useProviderStore.getState().activeProviderId });
+        const didSwitchModel = getActiveTabState().sessionMeta.modelSwitched || getActiveTabState().sessionMeta.providerSwitched;
+        console.log('[TOKENICODE:session] starting session', { cwd, stdinId: preGeneratedId, mode: liveSessionMode, provider: useProviderStore.getState().activeProviderId, modelSwitch: !!didSwitchModel, resumeSessionId: existingSessionId });
         const session = await bridge.startSession({
           prompt: text,
           cwd,
@@ -1070,11 +1083,22 @@ export function InputBar() {
           session_mode: (liveSessionMode === 'ask' || liveSessionMode === 'plan') ? liveSessionMode : undefined,
           provider_id: useProviderStore.getState().activeProviderId || undefined,
           permission_mode: mapSessionModeToPermissionMode(liveSessionMode),
+          model_switch: didSwitchModel ? true : undefined,
         });
         console.log('[TOKENICODE:session] started successfully', { sessionId: session.session_id, pid: session.pid, cli: session.cli_path });
 
         // Store both: session_id for tracking, stdinId (preGeneratedId) for stdin communication
-        setSessionMeta(tabId, { sessionId: session.session_id, stdinId: preGeneratedId, envFingerprint: envFingerprint(), spawnedModel: resolveModelForProvider(selectedModel) });
+        // Also clear model/provider switch flags — the switch has been handled by this spawn.
+        setSessionMeta(tabId, {
+          sessionId: session.session_id,
+          stdinId: preGeneratedId,
+          envFingerprint: envFingerprint(),
+          spawnedModel: resolveModelForProvider(selectedModel),
+          modelSwitched: false,
+          providerSwitched: false,
+          modelSwitchPendingText: undefined,
+          providerSwitchPendingText: undefined,
+        });
         // Note: stdinId → tabId mapping already registered before listener setup (TK-329)
 
         // Track the session and refresh conversation list

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -23,6 +23,10 @@ export interface StartSessionParams {
    *  "acceptEdits" | "default" | "plan" | "bypassPermissions"
    *  When not "bypassPermissions", enables structured permission requests via SDK protocol. */
   permission_mode?: string;
+  /** When true and resume_session_id is set, strip thinking blocks from the session JSONL
+   *  before resuming. This prevents "invalid thinking signature" 400 errors when switching
+   *  to a different model that can't verify the old model's cryptographic signatures. */
+  model_switch?: boolean;
 }
 
 export interface SessionInfo {


### PR DESCRIPTION
## Problem

When switching models mid-session (e.g. Claude Sonnet → Opus, or switching API providers), the CLI resumes from a JSONL file that contains the previous model's cryptographic thinking signatures. The new model cannot verify these signatures and rejects the request with a **400 error**:

> "Input to `thinking.signature` doesn't match the expected value for this `thinking` block"

This causes the session to either:
1. Silently retry without `--resume`, losing all conversation context, or
2. Fail entirely with a 400 error visible to the user.

The upstream `main` branch does not currently handle this scenario — the frontend cleans thinking blocks from the local message list (cosmetic), but the **JSONL file on disk** still contains the invalid signatures, so the CLI's `--resume` flag hits the same 400.

## Solution

Strip `thinking` and `redacted_thinking` content blocks from the session JSONL file **on disk** before passing `--resume` to the CLI. This preserves all conversation text while removing the cryptographic signatures that the new model can't verify.

### Changes

| File | What changed |
|------|-------------|
| `src-tauri/src/lib.rs` | `find_session_jsonl()`: locates session JSONL by scanning `~/.claude/projects/*/`. UUID validation prevents path traversal. |
| `src-tauri/src/lib.rs` | `strip_thinking_blocks_from_session()`: reads JSONL line-by-line, removes thinking/redacted_thinking blocks from assistant message content arrays, writes via temp file + atomic rename (Unix) / backup-rollback (Windows). Creates `.jsonl.bak` backup before overwriting. |
| `src-tauri/src/lib.rs` | `start_claude_session`: new `model_switch` param — when true and `resume_session_id` is set, calls the strip function before resume. **Best-effort**: failure is logged but does NOT block resume. The existing auto-retry safety net in `useStreamProcessor.ts` catches any remaining errors. |
| `src-tauri/src/commands/claude_process.rs` | `StartSessionParams`: added `model_switch: Option<bool>` field. |
| `src/lib/tauri-bridge.ts` | `StartSessionParams`: added `model_switch?: boolean` field. |
| `src/components/chat/InputBar.tsx` | Provider-switch path now also cleans thinking blocks from local message history (previously only model-switch path did this). Passes `model_switch: true` to Rust when either model or provider changed. Clears switch flags after successful spawn to prevent flag leakage. |

### Design decisions

- **JSONL-level strip, not API-level**: Stripping at the file level before resume is simpler and more reliable than modifying API requests. The JSONL is the CLI's source of truth for `--resume`.
- **Best-effort + auto-retry safety net**: If the strip fails (permissions, I/O error), the resume proceeds anyway. The existing `isThinkingSignatureError` retry path in `useStreamProcessor.ts` catches the 400 and retries without resume as a last resort.
- **Backup before overwrite**: The original JSONL is copied to `.jsonl.bak` before modification, so no data is permanently lost.
- **UUID validation on session_id**: `find_session_jsonl` validates the session ID as a UUID before using it in path construction, preventing path traversal attacks.
- **Windows-safe file replacement**: Uses a two-step rename with rollback on Windows where atomic rename-over-existing isn't supported.

## Test plan

- [x] `cargo check`: clean (38 pre-existing warnings, 0 errors)
- [x] `cargo test --lib strip_thinking_tests`: 5/5 passed
  - Removes thinking + redacted_thinking blocks, preserves text/tool_use/tool_result
  - Handles empty content arrays and user messages (no-op)
  - Handles all-thinking content (results in empty array)
- [x] `pnpm build`: green
- [x] Manual GUI test: switch model mid-session → conversation context preserved, no 400 error