### PR TITLE
fix: SDK control protocol bug cluster — 6 root-cause fixes for recurring issues

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1571,10 +1571,24 @@ async fn start_claude_session(
                                 .or_else(|| request.get("toolUseId"))
                                 .and_then(|v| v.as_str())
                                 .map(String::from);
+                            // P0-1 (#39): forward parent_tool_use_id and agent_id so the
+                            // frontend can compute sub-agent depth. Without these, every
+                            // sub-agent permission freezes the main input because
+                            // resolveAgentId falls back to "main agent" depth 0.
+                            let parent_tool_use_id = request
+                                .get("parent_tool_use_id")
+                                .or_else(|| request.get("parentToolUseId"))
+                                .and_then(|v| v.as_str())
+                                .map(String::from);
+                            let agent_id = request
+                                .get("agent_id")
+                                .or_else(|| request.get("agentId"))
+                                .and_then(|v| v.as_str())
+                                .map(String::from);
 
                             eprintln!(
-                                "[TOKENICODE] permission request: tool={} request_id={}",
-                                tool_name, request_id
+                                "[TOKENICODE] permission request: tool={} request_id={} parent_tool_use_id={:?} agent_id={:?}",
+                                tool_name, request_id, parent_tool_use_id, agent_id
                             );
 
                             // Emit as a special stream message (reuses the working stream channel)
@@ -1585,6 +1599,8 @@ async fn start_claude_session(
                                 "input": input,
                                 "description": description,
                                 "tool_use_id": tool_use_id,
+                                "parent_tool_use_id": parent_tool_use_id,
+                                "agent_id": agent_id,
                             });
                             let _ = emit_to_frontend(&app_clone, &stream_event, perm_payload);
                             continue; // Don't forward to stream as normal msg

--- a/src/components/chat/TiptapEditor.tsx
+++ b/src/components/chat/TiptapEditor.tsx
@@ -152,6 +152,19 @@ export const TiptapEditor = forwardRef<TiptapEditorHandle, TiptapEditorProps>(
         handlePaste: (_view, event) => {
           return onPasteRef.current?.(event as unknown as ClipboardEvent) === true;
         },
+        // Prevent Finder file drags from inserting raw text paths into the editor.
+        // macOS WKWebView delivers Finder drags both via Tauri's native onDragDropEvent
+        // (correct chip insertion path) AND via the browser-level DOM drop event.
+        // Without this guard, ProseMirror's default drop handler inserts text/plain
+        // content from the DataTransfer, racing with the chip insertion.
+        handleDrop: (_view, event) => {
+          const dt = event.dataTransfer;
+          if (!dt) return false;
+          // Block drops that carry files (Finder drag) — let Tauri handle them.
+          // Non-file drops (URL drags from browser tabs) pass through to ProseMirror.
+          if (dt.types.includes('Files') || dt.files.length > 0) return true;
+          return false;
+        },
       },
       onUpdate: ({ editor: ed }) => {
         // Skip store updates during IME composition to avoid React re-renders

--- a/src/hooks/useRewind.ts
+++ b/src/hooks/useRewind.ts
@@ -61,6 +61,9 @@ export function useRewind() {
     const stdinId = state.sessionMeta.stdinId;
     if (stdinId) {
       await bridge.killSession(stdinId).catch(() => {});
+      // Unlisten BEFORE unregistering: Tauri's unlisten synchronously removes
+      // the listener, so in-flight events are dropped before they reach
+      // handleStreamMessage, eliminating the routing race window.
       if ((window as any).__claudeUnlisteners?.[stdinId]) {
         (window as any).__claudeUnlisteners[stdinId]();
         delete (window as any).__claudeUnlisteners[stdinId];
@@ -68,6 +71,7 @@ export function useRewind() {
       if ((window as any).__claudeUnlisten) {
         (window as any).__claudeUnlisten = null;
       }
+      useSessionStore.getState().unregisterStdinTab(stdinId);
     }
   }, []);
 

--- a/src/hooks/useStreamProcessor.ts
+++ b/src/hooks/useStreamProcessor.ts
@@ -1,7 +1,7 @@
 import { useCallback, type MutableRefObject } from 'react';
 import { useChatStore, generateMessageId, type ChatMessage } from '../stores/chatStore';
 import { useSettingsStore, mapSessionModeToPermissionMode, getEffectiveMode } from '../stores/settingsStore';
-import { useSessionStore } from '../stores/sessionStore';
+import { useSessionStore, setOrphanDrainCallback } from '../stores/sessionStore';
 import { useAgentStore, resolveAgentId, getAgentDepth } from '../stores/agentStore';
 import { useFileStore } from '../stores/fileStore';
 import { bridge, onClaudeStream, onClaudeStderr } from '../lib/tauri-bridge';
@@ -51,6 +51,91 @@ interface _StreamBuffer {
 }
 const _streamBuffers = new Map<string, _StreamBuffer>();
 
+// --- Orphan queue (#57-B) ---
+// When _doFlush fires after the stdinId has been unregistered AND
+// selectedSessionId is null, the previous code silently wiped the buffer.
+// Instead, stash the text in an orphan queue keyed by stdinId. The queue is
+// drained when registerStdinTab(stdinId, tabId) is later called.
+interface _OrphanEntry { text: string; thinking: string; expiresAt: number; }
+const _ORPHAN_TTL_MS = 5_000;
+const _ORPHAN_PER_STDIN_CAP_CHARS = 1 * 1024 * 1024;
+const _ORPHAN_TOTAL_CAP_CHARS = 10 * 1024 * 1024;
+const _orphanQueue = new Map<string, _OrphanEntry>();
+
+function _orphanTotalChars(): number {
+  let total = 0;
+  for (const entry of _orphanQueue.values()) total += entry.text.length + entry.thinking.length;
+  return total;
+}
+
+function _stashOrphan(stdinId: string, text: string, thinking: string) {
+  if (!text && !thinking) return;
+  _expireOrphans();
+  const existing = _orphanQueue.get(stdinId);
+  const merged: _OrphanEntry = existing
+    ? { text: existing.text + text, thinking: existing.thinking + thinking, expiresAt: Date.now() + _ORPHAN_TTL_MS }
+    : { text, thinking, expiresAt: Date.now() + _ORPHAN_TTL_MS };
+  const mergedChars = merged.text.length + merged.thinking.length;
+  if (mergedChars > _ORPHAN_PER_STDIN_CAP_CHARS) {
+    console.error('[stream-flush] orphan entry exceeds per-stdinId cap, dropping:', stdinId);
+    _orphanQueue.delete(stdinId);
+    return;
+  }
+  _orphanQueue.set(stdinId, merged);
+  if (_orphanTotalChars() > _ORPHAN_TOTAL_CAP_CHARS) {
+    while (_orphanTotalChars() > _ORPHAN_TOTAL_CAP_CHARS) {
+      const oldest = _orphanQueue.keys().next().value;
+      if (!oldest) break;
+      _orphanQueue.delete(oldest);
+    }
+  }
+}
+
+function _expireOrphans() {
+  const now = Date.now();
+  for (const [id, entry] of _orphanQueue.entries()) {
+    if (entry.expiresAt <= now) _orphanQueue.delete(id);
+  }
+}
+
+/** Drain any orphan buffer for the given stdinId into its newly known tab. */
+export function drainOrphanBuffer(stdinId: string, tabId: string) {
+  _expireOrphans();
+  const entry = _orphanQueue.get(stdinId);
+  if (!entry) return;
+  const store = useChatStore.getState();
+  if (entry.text) store.updatePartialMessage(tabId, entry.text);
+  if (entry.thinking) store.updatePartialThinking(tabId, entry.thinking);
+  _orphanQueue.delete(stdinId);
+}
+
+// --- Shared pendingCommand completion helper (#27) ---
+// Both foreground and background handlers must clear pendingCommandMsgId when
+// a result or assistant event arrives. Without this, slash commands like /compact
+// that complete on a background tab leave the spinner stuck forever.
+interface CompletePendingCommandOpts {
+  output?: string;
+  costSummary?: { cost: string; duration: string; turns: string | number; input: string; output: string; };
+}
+
+export function completePendingCommand(tabId: string, opts: CompletePendingCommandOpts = {}) {
+  const store = useChatStore.getState();
+  const tab = store.getTab(tabId);
+  const pendingCmdMsgId = tab?.sessionMeta.pendingCommandMsgId;
+  if (!pendingCmdMsgId) return;
+  const cmdMsg = (tab?.messages ?? []).find((m) => m.id === pendingCmdMsgId);
+  store.updateMessage(tabId, pendingCmdMsgId, {
+    commandCompleted: true,
+    commandData: {
+      ...cmdMsg?.commandData,
+      ...(opts.output !== undefined ? { output: opts.output } : {}),
+      ...(opts.costSummary ? { costSummary: opts.costSummary } : {}),
+      completedAt: Date.now(),
+    },
+  });
+  store.setSessionMeta(tabId, { pendingCommandMsgId: undefined });
+}
+
 // Interval fallback: flush any stuck buffers every 200ms
 let _flushIntervalId: ReturnType<typeof setInterval> | null = null;
 
@@ -90,6 +175,9 @@ function _doFlush(stdinId: string, buf: _StreamBuffer) {
     useSessionStore.getState().registerStdinTab(stdinId, tabId);
   }
   if (!tabId) {
+    // Instead of silent wipe, stash text in orphan queue so a late
+    // registerStdinTab() can drain it. Bounded and TTL'd.
+    _stashOrphan(stdinId, buf.text, buf.thinking);
     buf.text = '';
     buf.thinking = '';
     return;
@@ -105,6 +193,10 @@ function _doFlush(stdinId: string, buf: _StreamBuffer) {
     buf.thinking = '';
   }
 }
+
+// Register the drain callback so sessionStore.registerStdinTab can flush
+// orphaned buffers without creating a circular import dependency.
+setOrphanDrainCallback(drainOrphanBuffer);
 
 function _scheduleStreamFlush(stdinId: string) {
   const buf = _getBuffer(stdinId);
@@ -342,6 +434,11 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
         if (evt.type === 'content_block_delta' && evt.delta?.type === 'text_delta') {
           const text = evt.delta.text || '';
           if (text) store.updatePartialMessage(tabId, text);
+        } else if (evt.type === 'content_block_delta' && evt.delta?.type === 'thinking_delta') {
+          // F1 (#57): background tabs must handle thinking_delta too,
+          // otherwise thinking content is silently lost on tab switch.
+          const thinking = evt.delta.thinking || '';
+          if (thinking) store.updatePartialThinking(tabId, thinking);
         }
         // Early detection: create plan_review card for background tab (Plan mode only).
         // Bypass auto-approves via Rust backend — no UI card needed.
@@ -391,6 +488,8 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
         break;
       }
       case 'assistant': {
+        // Clear pending command on assistant event (same as foreground)
+        completePendingCommand(tabId);
         const content = msg.message?.content;
         if (!Array.isArray(content)) break;
         // Selectively clear partial in tab — only wipe partialText if a text
@@ -551,6 +650,16 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
         break;
       }
       case 'result': {
+        // Clear pending command on result (e.g. /compact completing on background tab)
+        completePendingCommand(tabId, {
+          costSummary: msg.total_cost_usd != null ? {
+            cost: `$${msg.total_cost_usd?.toFixed(4) || '0'}`,
+            duration: msg.duration_ms ? `${(msg.duration_ms / 1000).toFixed(1)}s` : '',
+            turns: msg.num_turns ?? '',
+            input: msg.usage?.input_tokens?.toLocaleString() ?? '',
+            output: msg.usage?.output_tokens?.toLocaleString() ?? '',
+          } : undefined,
+        });
         store.setSessionStatus(tabId, msg.subtype === 'success' ? 'completed' : 'error');
         {
           const bgTab = store.getTab(tabId);

--- a/src/stores/sessionStore.ts
+++ b/src/stores/sessionStore.ts
@@ -1,6 +1,16 @@
 import { create } from 'zustand';
 import { bridge, SessionListItem, ContentSearchResult } from '../lib/tauri-bridge';
 
+// --- Orphan drain callback ---
+// useStreamProcessor exports drainOrphanBuffer(), but sessionStore can't import
+// it directly (circular dependency). Instead, useStreamProcessor registers its
+// drain function at module init via setOrphanDrainCallback(). registerStdinTab
+// then calls it so text that arrived before the mapping existed is flushed.
+let _orphanDrainCallback: ((stdinId: string, tabId: string) => void) | null = null;
+export function setOrphanDrainCallback(cb: (stdinId: string, tabId: string) => void) {
+  _orphanDrainCallback = cb;
+}
+
 // Persist custom session names in localStorage as fast cache,
 // and sync to disk via Tauri backend for durability.
 const CUSTOM_PREVIEWS_KEY = 'tokenicode_custom_previews';
@@ -190,6 +200,8 @@ export const useSessionStore = create<SessionState>()((set, get) => ({
     const next = { ...get().stdinToTab, [stdinId]: tabId };
     saveStdinToTab(next);
     set({ stdinToTab: next });
+    // Drain any orphaned stream buffer that arrived before this mapping existed
+    _orphanDrainCallback?.(stdinId, tabId);
   },
 
   unregisterStdinTab: (stdinId) => {


### PR DESCRIPTION
## Summary

Six bugs that have been reported, partially fixed, and re-opened across multiple releases (#57, #49, #44, #39, #30, #27). Each previous fix addressed a symptom without closing the underlying structural gap, causing regressions when adjacent code changed.

This PR addresses all six root causes together. Each section below explains **what the current code does wrong** and **why the previous fix was incomplete**.

---

## Bug 1: Background tab `thinking_delta` silently dropped (#57)

**Current behavior**: switch tabs while model is thinking → thinking content for background tab is permanently lost.

**Root cause**: `handleBackgroundStreamMessage` handles `text_delta` but has no handler for `thinking_delta`. The foreground handler has both.

```
// Foreground (line ~933): ✅ handles both
if (evt.delta?.type === 'text_delta') { ... }
else if (evt.delta?.type === 'thinking_delta') { ... }

// Background (line ~434): ❌ only handles text
if (evt.delta?.type === 'text_delta') { ... }
// thinking_delta → silently ignored
```

**Fix**: Added `thinking_delta` case in background `stream_event` handler. **5 lines.**

---

## Bug 2: `/compact` spinner stuck forever on tab switch (#27)

**Current behavior**: run `/compact` → switch to another tab → switch back → command processing card spins forever.

**Root cause**: The foreground `result` and `assistant` handlers clear `pendingCommandMsgId` (4 separate code paths). The background handler's `result` and `assistant` cases never clear it.

**Fix**: Extracted a shared `completePendingCommand()` helper called by both handlers. Also injects `costSummary` into the command card on completion. **35 lines.**

---

## Bug 3: Race condition silently wipes stream buffer (#57-B)

**Current behavior**: Occasionally, a few characters at the end of a response disappear. No error, no warning.

**Root cause**: `_doFlush()` line 92-95:

```typescript
if (!tabId) {
    buf.text = '';     // ← SILENT DATA LOSS
    buf.thinking = '';
    return;
}
```

When `process_exit` arrives during tab teardown, both `stdinToTab` mapping and `selectedSessionId` can be null simultaneously. The buffer is wiped without any record.

**Why previous fix was incomplete**: The `_doFlush` helper (correctly extracted in a recent refactor) inherited the silent-wipe behavior from the inline code it replaced. The `selectedSessionId` fallback catches the common case, but the null+null edge case still loses data.

**Fix**: Added orphan queue (`_stashOrphan` / `drainOrphanBuffer`):
- Bounded: 1M chars per stdinId, 10M total, 5s TTL
- `_doFlush` stashes instead of wiping when no tab mapping exists
- `sessionStore.registerStdinTab` triggers drain via callback (avoids circular import)
- Dead entries are cleaned on every stash and drain call

**55 lines.**

---

## Bug 4: Sub-agent permissions freeze main input (#39)

**Current behavior**: When a sub-agent (e.g. inside a `dispatch` tool) requests permission, the **main** input bar locks up. User must switch tabs and back to recover.

**Root cause**: `lib.rs` emits `tokenicode_permission_request` without `parent_tool_use_id` or `agent_id`. The frontend's `resolveAgentId()` can't compute sub-agent depth → defaults to depth 0 (main agent) → `isAwaiting` locks the main input.

The SDK control protocol **does** send `parent_tool_use_id` and `agent_id` in the raw JSON request. The Rust backend just never extracts them:

```rust
// Current code — missing fields:
let perm_payload = serde_json::json!({
    "type": "tokenicode_permission_request",
    "request_id": request_id,
    "tool_name": tool_name,
    "input": input,
    "description": description,
    "tool_use_id": tool_use_id,
    // ← parent_tool_use_id: MISSING
    // ← agent_id: MISSING
});
```

**Fix**: Extract `parent_tool_use_id` (+ `parentToolUseId` camelCase fallback) and `agent_id` (+ `agentId`) from the raw control request JSON. Forward both in `perm_payload`. **20 lines.**

---

## Bug 5: File drag from Finder inserts both chip AND raw text path

**Current behavior**: Drag a file from Finder into the input → get a styled file chip AND a raw `/Users/foo/bar.txt` text pasted into the editor.

**Root cause**: `TiptapEditor.editorProps` has no `handleDrop`. macOS WKWebView delivers Finder drags via two parallel paths:
1. Tauri's native `onDragDropEvent` → correct chip insertion
2. Browser DOM drop event → ProseMirror inserts `text/plain` from DataTransfer

Without `handleDrop`, both fire and race.

**Fix**: Added `handleDrop` that returns `true` (blocking ProseMirror default) when DataTransfer carries `Files`. Non-file drops (URL drags) pass through normally. **13 lines.**

---

## Bug 6: Kill ordering race in `useRewind` leaves stale routing

**Current behavior**: After rewind, events from the killed process occasionally route to the wrong tab.

**Root cause**: `useRewind.killProcess()` calls `kill → unlisten` but never calls `unregisterStdinTab()`. The stale `stdinToTab` entry can cause late-arriving events to route to the wrong tab via the fallback path in `_doFlush`.

**Fix**: Added `unregisterStdinTab(stdinId)` after unlisten. **4 lines.**

---

## Conflict note

This PR may conflict with #77 (thinking block strip for model switch) in `lib.rs` — both modify the permission handling section. The changes are additive and non-overlapping in logic. If both are merged, a simple conflict resolution (keep both additions) is correct.

## Files changed

| File | Lines | What |
|------|-------|------|
| `src/hooks/useStreamProcessor.ts` | +111 | Orphan queue, completePendingCommand, background thinking_delta |
| `src-tauri/src/lib.rs` | +20 | parent_tool_use_id + agent_id extraction |
| `src/components/chat/TiptapEditor.tsx` | +13 | handleDrop for file drags |
| `src/stores/sessionStore.ts` | +12 | Orphan drain callback |
| `src/hooks/useRewind.ts` | +4 | unregisterStdinTab on kill |

## Verification

- [x] `pnpm build`: green
- [x] `cargo check`: clean (38 pre-existing warnings, 0 errors)
- [x] Manual testing: all 6 scenarios verified in GUI