### PR TITLE
feat: E2E test harness for automated GUI testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,5 @@ package-lock.json
 # Obsidian
 .obsidian/
 
-# Local test data (suites and runs are local-only)
-.test/
+# Test run data (local-only, not shared)
+.test/runs/

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ package-lock.json
 
 # Obsidian
 .obsidian/
+
+# Local test data (suites and runs are local-only)
+.test/

--- a/.test/CLI-TEST-TOOL.md
+++ b/.test/CLI-TEST-TOOL.md
@@ -1,0 +1,851 @@
+# TOKENICODE CLI Test Tool & Batch Test Runner
+
+CLI 工具 + 批量测试运行器，用于从命令行驱动 TOKENICODE GUI 进行端到端测试。仅在 debug 构建下可用。
+
+---
+
+## 一、架构
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  AI / 人类                                                   │
+│  ├── 直接调用: node scripts/tokenicode-cli.mjs <command>     │
+│  └── 批量测试: node scripts/run-tests.mjs <test.json>       │
+│       └── 内部逐条调用 tokenicode-cli.mjs                    │
+└────────────────────────┬────────────────────────────────────┘
+                         │ NDJSON over Unix socket
+                         │ /tmp/tokenicode-test.sock
+                         v
+┌─────────────────────────────────────────────────────────────┐
+│  Test harness transport (Rust, debug builds only)                  │
+│  cfg(debug_assertions) 门控，release 构建完全不含             │
+└────────────────────────┬────────────────────────────────────┘
+                         │ Tauri event system
+                         v
+┌─────────────────────────────────────────────────────────────┐
+│  Frontend JS listeners → window.__tokenicode_test            │
+│  import.meta.env.DEV 门控，production build 自动剥离         │
+│  通过 Zustand store 直操 / DOM 查询 控制 GUI                 │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**两阶段测试工作流**：
+
+```
+阶段 1（设计）：AI 分析 bug/feature → 编写测试定义 JSON
+阶段 2（执行）：run-tests.mjs 机械化执行 → 全量记录 → 输出结构化报告 JSON
+阶段 3（分析）：AI 读报告 → 定位问题 → 迭代修复
+```
+
+执行阶段无 AI 参与，纯机械化。
+
+---
+
+## 二、前置条件
+
+1. 启动 TOKENICODE dev 构建：`pnpm tauri dev`
+2. 确认控制台输出：`[TOKENICODE] Test harness registered on /tmp/tokenicode-test.sock`
+3. 验证连通性：`node scripts/tokenicode-cli.mjs ping`（应返回 `{"ok":true,"pong":true}`）
+
+---
+
+## 二点五、AI 测试行为准则
+
+### 界面状态判断：元素查询优先，截图仅兜底
+
+**禁止用截图判断界面状态。** 必须使用 `query-page --mode map` 或 `wait-for --selector` 来判断 UI 元素是否存在、状态是否正确。
+
+截图（`screenshot`）仅限以下场景：
+- 需要人工肉眼确认视觉呈现问题（样式错乱、布局偏移、颜色异常）
+- 所有元素查询手段都无法回答当前问题
+
+```
+✅ query-page --mode map → 检查 send-button 是否存在 → 判断编辑器可用
+✅ wait-for --selector '[data-testid=permission-card]' → 判断权限卡片出现
+✅ status → 检查 active/phase/messageCount
+❌ screenshot → 看图猜编辑器在不在
+❌ get-visible-text → 通过搜索文本判断元素存在（fragile，文本会变）
+```
+
+### 操作前必检：编辑器是否挂载
+
+`type` 和 `send` 依赖 TipTap 编辑器挂载。以下状态 **没有编辑器**：
+- 欢迎页（刚启动 / `new-session` 后 / 重启后）
+- 无项目选中的空白页
+
+**每次 `type` 前必须确认编辑器已挂载**，未通过则先 `switch-session`：
+
+```bash
+# 检查编辑器
+node scripts/tokenicode-cli.mjs wait-for --selector '[data-testid=send-button]' --timeout 5000
+# → ok：可以 type + send
+# → timeout/error：先 switch-session <SESSION_ID>，再重试
+```
+
+### 正确的新会话流程
+
+```bash
+# ✅ 推荐：指定工作区创建新会话（有编辑器，可直接 type）
+node scripts/tokenicode-cli.mjs new-session --cwd ~/Documents
+node scripts/tokenicode-cli.mjs check-editor   # 确认编辑器可用
+node scripts/tokenicode-cli.mjs type "hello"
+node scripts/tokenicode-cli.mjs send
+
+# ✅ 备选：切到已有会话
+node scripts/tokenicode-cli.mjs switch-session <SESSION_ID>
+
+# ❌ 错误：new-session 无参数后直接 type（欢迎页无编辑器，type 静默失败）
+node scripts/tokenicode-cli.mjs new-session
+node scripts/tokenicode-cli.mjs type "hello"  # 无效
+```
+
+`new-session` 无参数仅用于：测试欢迎页 UI、重置到空白状态。
+
+### 重启应用
+
+```bash
+# 同窗口重启（webview reload，推荐）
+node scripts/tokenicode-cli.mjs restart
+
+# 硬重启（杀进程 + 新窗口，仅 Tauri 后端出问题时用）
+node scripts/tokenicode-cli.mjs relaunch
+```
+
+---
+
+## 三、CLI 工具：tokenicode-cli.mjs
+
+### 基本用法
+
+```bash
+node scripts/tokenicode-cli.mjs <command> [args] [--flags]
+```
+
+所有输出为单行 JSON：`{"ok":true, ...}` 或 `{"ok":false, "error":"..."}`。零外部依赖。
+
+### 全部命令（30 个）
+
+#### 健康检查
+
+```bash
+# 检测 TOKENICODE 是否在运行
+node scripts/tokenicode-cli.mjs ping
+# → {"ok":true,"pong":true}
+
+# 全局状态快照（最常用的诊断命令）
+node scripts/tokenicode-cli.mjs status
+# → {"ok":true,"session":"uuid","sessionCount":52,"model":"claude-opus-4-6",
+#    "provider":"id-or-null","active":false,"phase":null,
+#    "pendingPermission":false,"settingsOpen":false,"messageCount":16}
+
+# 同窗口重启（webview reload，不开新窗口）
+node scripts/tokenicode-cli.mjs restart
+node scripts/tokenicode-cli.mjs restart --timeout 30000
+# → {"ok":true,"restarted":true,"mode":"reload","elapsed":10000}
+
+# 硬重启（杀进程 + 重新 spawn，开新窗口，仅 Tauri 后端出问题时使用）
+node scripts/tokenicode-cli.mjs relaunch
+node scripts/tokenicode-cli.mjs relaunch --timeout 120000
+# → {"ok":true,"restarted":true,"elapsed":7000,"pid":12345}
+```
+
+`status` 返回字段：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `session` | string\|null | 当前 session ID |
+| `sessionCount` | number | 总 session 数 |
+| `model` | string | 当前模型 ID（如 `claude-opus-4-6`） |
+| `provider` | string\|null | 当前 provider ID（null = 系统默认） |
+| `active` | boolean | 会话是否活跃（覆盖 thinking/writing/tool/awaiting 四个阶段） |
+| `phase` | string\|null | 当前活跃阶段：`thinking` / `writing` / `tool` / `awaiting` / `completed` / `null` |
+| `pendingPermission` | boolean | 是否有等待响应的权限请求 |
+| `settingsOpen` | boolean | 设置面板是否打开 |
+| `messageCount` | number | 当前 tab 的消息总数 |
+
+`restart` 工作流程：webview `location.reload()` → 轮询 `execute_js` 直到就绪。
+
+`relaunch` 工作流程：
+1. 通过 `lsof -t -U` 查找监听 socket 的进程 PID（尊重 `TOKENICODE_SOCKET` 环境变量）
+2. 解析真实 PGID（`ps -o pgid=`），SIGTERM 杀进程组
+3. 等待进程退出（最多 10s），超时升级 SIGKILL
+4. 杀 Vite dev server（port 1420）
+5. 清理残留 socket 文件
+5. 在项目根目录 spawn `pnpm tauri dev`（detached）
+6. 轮询 ping 直到应用就绪
+
+#### 对话
+
+```bash
+# 输入文字到 TipTap 编辑器
+node scripts/tokenicode-cli.mjs type "你好"
+
+# 发送消息（触发 Claude CLI）
+node scripts/tokenicode-cli.mjs send
+
+# 停止生成
+node scripts/tokenicode-cli.mjs stop
+
+# 删除当前 session（清理 tab + 终止 CLI 进程，防止 session 累积）
+node scripts/tokenicode-cli.mjs delete-session
+# → {"ok":true,"deleted":true,"session":"desk_..."}
+
+# 读消息（默认最后 10 条）
+node scripts/tokenicode-cli.mjs get-messages
+node scripts/tokenicode-cli.mjs get-messages --last 3
+node scripts/tokenicode-cli.mjs get-messages --all
+# → {"ok":true,"messages":[...],"total":16}
+
+# 默认返回摘要（content 截断 150 字，thinking → [thinking]，tool_result → 前 80 字）
+# 需要完整内容时加 --full
+node scripts/tokenicode-cli.mjs get-messages --last 5 --full
+
+# 检查编辑器是否可用（type/send 前必检）
+node scripts/tokenicode-cli.mjs check-editor
+# → {"ok":true,"hasEditor":true,"hasChatPanel":true,"session":"uuid"}
+
+# 检查是否正在生成
+node scripts/tokenicode-cli.mjs is-streaming
+node scripts/tokenicode-cli.mjs is-streaming --tab <TAB_ID>
+```
+
+消息对象字段：
+
+| 字段 | 说明 |
+|------|------|
+| `id` | 消息唯一 ID |
+| `role` | `user` / `assistant` / `system` |
+| `type` | `text` / `thinking` / `tool_use` / `tool_result` |
+| `content` | 消息文本内容 |
+| `toolName` | tool_use 时的工具名 |
+| `subAgentDepth` | sub-agent 嵌套深度（0=主 agent） |
+| `timestamp` | 时间戳 |
+
+#### Session 管理
+
+```bash
+node scripts/tokenicode-cli.mjs get-active-session
+node scripts/tokenicode-cli.mjs get-all-sessions
+node scripts/tokenicode-cli.mjs switch-session <SESSION_ID>  # 完整加载：读 JSONL + 设 working dir + 填充消息
+node scripts/tokenicode-cli.mjs new-session                  # 无参数：导航到欢迎页（无编辑器）
+node scripts/tokenicode-cli.mjs new-session --cwd /path/to   # 有 cwd：创建可用新会话（有编辑器）
+```
+
+> **`new-session` 无参数**时只导航到欢迎页（无编辑器，不可 type）。  
+> **`new-session --cwd <path>`** 在指定工作区创建新会话，编辑器可用，可以直接 type + send。  
+> 详见「二点五、正确的新会话流程」。
+
+#### 模型和 Provider
+
+```bash
+node scripts/tokenicode-cli.mjs get-current-model
+node scripts/tokenicode-cli.mjs get-current-provider
+node scripts/tokenicode-cli.mjs switch-model claude-sonnet-4-6
+node scripts/tokenicode-cli.mjs switch-provider <PROVIDER_ID>
+node scripts/tokenicode-cli.mjs switch-provider null   # 重置为系统默认
+```
+
+#### 设置面板
+
+```bash
+node scripts/tokenicode-cli.mjs open-settings
+node scripts/tokenicode-cli.mjs close-settings
+node scripts/tokenicode-cli.mjs switch-settings-tab provider   # general|provider|cli|mcp
+```
+
+#### 权限处理
+
+```bash
+node scripts/tokenicode-cli.mjs allow-permission
+node scripts/tokenicode-cli.mjs deny-permission
+```
+
+#### 页面内容
+
+```bash
+# 获取页面可见文本（纯文字，无 HTML 噪音）
+node scripts/tokenicode-cli.mjs get-visible-text
+node scripts/tokenicode-cli.mjs get-visible-text --selector '[data-testid=chat-messages]'
+
+# 截图（返回文件路径，用 Read 工具查看图片）
+node scripts/tokenicode-cli.mjs screenshot
+
+# 页面结构/状态/应用信息
+node scripts/tokenicode-cli.mjs query-page --mode state
+node scripts/tokenicode-cli.mjs query-page --mode info
+node scripts/tokenicode-cli.mjs query-page --mode map
+
+# 精简元素查询（仅交互元素 + 不含文本内容，大幅减少输出噪音）
+node scripts/tokenicode-cli.mjs query-page --mode map --interactive-only
+node scripts/tokenicode-cli.mjs query-page --mode map --interactive-only --no-content
+
+# 原始 HTML
+node scripts/tokenicode-cli.mjs get-dom
+```
+
+#### 等待
+
+```bash
+# 等待文本出现
+node scripts/tokenicode-cli.mjs wait-for --text "收到" --timeout 5000
+
+# 等待元素出现
+node scripts/tokenicode-cli.mjs wait-for --selector '[data-testid=permission-card]'
+
+# 等待消息生成完成（轮询 status，超时=失败）
+node scripts/tokenicode-cli.mjs wait-until-done --timeout 60000
+
+# 等待特定 phase（如等模型进入 writing 阶段再中断）
+node scripts/tokenicode-cli.mjs wait-for-phase writing --timeout 15000
+# phases: thinking | writing | tool | awaiting | completed
+
+# 纯延时（不检查状态，用于时序控制）
+node scripts/tokenicode-cli.mjs delay 3000
+```
+
+`wait-until-done` 返回值：
+
+| 结果 | ok | status | 下一步 |
+|------|-----|--------|--------|
+| 生成完成 | `true` | `completed` | `get-messages` 读回复 |
+| 权限阻塞 | `true` | `permission_pending` | `allow-permission` 或 `deny-permission` |
+| 超时 | **`false`** | `timeout` | 步骤失败。若需继续执行后续步骤，加 `continueOnError: true` |
+
+> **注意**：`wait-until-done` 超时返回 `ok: false`（步骤失败）。如果你需要"等 N 秒然后继续"的行为，用 `delay` 命令。
+
+`wait-for-phase` 返回值：
+
+| 结果 | ok | 说明 |
+|------|-----|------|
+| 到达目标 phase | `true` | 返回完整 status 数据 |
+| session 提前结束 | `false` | session 在到达目标 phase 前就结束了 |
+| 超时 | `false` | 未在超时内到达目标 phase |
+
+#### 原始 JS 执行
+
+```bash
+node scripts/tokenicode-cli.mjs exec "document.title"
+node scripts/tokenicode-cli.mjs exec "JSON.stringify(window.__tokenicode_test.status())"
+```
+
+### 默认超时
+
+| 命令 | 默认超时 |
+|------|---------|
+| 普通命令 | 10s |
+| `screenshot` | 15s |
+| `switch-session` | 30s |
+| `wait-until-done` | 60s |
+| `wait-for` | 10s |
+| `wait-for-phase` | 30s |
+| `delay` | 无（按参数时长） |
+| `restart` | 30s |
+| `relaunch` | 120s |
+
+### 环境变量
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `TOKENICODE_SOCKET` | `/tmp/tokenicode-test.sock` | 覆盖 socket 路径（restart 命令也遵循） |
+
+### 可用的 data-testid
+
+用于 `get-visible-text --selector` 和 `wait-for --selector`：
+
+| testid | 位置 |
+|--------|------|
+| `chat-input-editor` | TipTap 编辑器容器 |
+| `send-button` | 发送按钮 |
+| `stop-button` | 停止按钮 |
+| `chat-messages` | 聊天消息滚动区域 |
+| `model-selector` | 模型选择器触发按钮 |
+| `model-option-{id}` | 模型选项 |
+| `new-session-button` | 新建 session 按钮 |
+| `current-session-card` | 当前 session 卡片 |
+| `session-item-{sessionId}` | session 列表项 |
+| `permission-card` | 权限请求卡片 |
+| `permission-allow-button` | 允许按钮 |
+| `permission-deny-button` | 拒绝按钮 |
+| `settings-button` | 设置按钮 |
+| `settings-panel` | 设置面板 |
+| `settings-close-button` | 关闭设置按钮 |
+| `settings-tab-{id}` | 设置 tab（general/provider/cli/mcp） |
+| `provider-card-{id}` | Provider 卡片 |
+| `provider-inherit-button` | 继承系统默认 Provider 按钮 |
+
+---
+
+## 四、批量测试运行器：run-tests.mjs
+
+### 基本用法
+
+```bash
+node scripts/run-tests.mjs <test-file.json> [--flags]
+```
+
+### 运行器参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--report <path>` | `/tmp/tokenicode-test-report-{时间戳}.json` | 报告输出路径 |
+| `--retry <N>` | `0` | 全局重试次数（单测定义 `retry` 优先） |
+| `--test-timeout <ms>` | `120000` | 单测超时（硬上限：step 超时被 clamp 到剩余预算） |
+| `--stop-after <N>` | `3` | 连续 N 次失败后触发 restart |
+| `--no-auto-restart` | — | 禁用自动 restart |
+| `--detail <level>` | `standard` | 报告详尽度：`minimal`（无状态快照）、`standard`（状态快照 + UI 命令可见文本）、`full`（状态快照 + 每步可见文本） |
+| `--no-snapshots` | — | 禁用状态快照（加速执行，但丢失前后状态对比） |
+
+### 运行器行为
+
+1. **预检**：启动时 `ping` 检查 TOKENICODE 是否在运行
+2. **Schema 校验**：验证所有测试定义的 `steps`/`setup`/`teardown` 格式，不合法直接退出
+3. **串行执行**：一个测试完了才跑下一个
+4. **全量记录**：每步的输入命令、输出 JSON、耗时、执行前后 UI 状态快照、可见文本
+5. **自动重试**：step 失败 → 重试整个测试（所有 attempt 历史都保留在报告中）
+6. **超时硬上限**：`testTimeout` 是硬限制，每步的超时被 clamp 到剩余测试预算（teardown 例外：至少 3s 做清理）
+7. **兜底策略**：
+   - 连续 3 个测试失败 → 自动 `restart`（杀掉 Tauri 进程树，重启 `pnpm tauri dev`）
+   - restart 成功 → 重置计数，继续
+   - restart 也失败 → 终止运行，剩余测试标记 `skipped`
+8. **stdout**：每个测试一行 JSON 摘要 + 最终一行 `_summary`
+9. **报告文件**：完整 JSON 报告存盘，`_summary` 中包含 `reportWritten` 和 `reportWriteError` 告知写入状态
+
+### 测试定义格式
+
+```json
+{
+  "tests": [
+    {
+      "name": "测试名称（必填，显示在报告和摘要中）",
+      "timeout": 60000,
+      "retry": 1,
+      "captureSnapshots": true,
+      "setup": [
+        {"cmd": "switch-session", "args": ["SESSION_ID"]}
+      ],
+      "steps": [
+        {"cmd": "type", "args": ["测试文本"]},
+        {"cmd": "send"},
+        {"cmd": "wait-until-done", "flags": {"timeout": "30000"}},
+        {"cmd": "get-messages", "flags": {"last": "2"}},
+        {"cmd": "status"}
+      ],
+      "teardown": [
+        {"cmd": "stop"}
+      ]
+    }
+  ],
+  "retry": 0,
+  "captureSnapshots": true,
+  "testTimeout": 120000
+}
+```
+
+也支持纯数组 `[{...}, {...}]` 或单个测试对象 `{name, steps}` 作为顶层。
+
+#### Step 字段
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `cmd` | string | 是 | tokenicode-cli.mjs 命令名 |
+| `args` | string[] | 否 | 位置参数 |
+| `flags` | object | 否 | `--key value` 标志，值为字符串或 `true`（布尔标志） |
+| `timeout` | number | 否 | 该步超时（ms），默认 30s，受 testTimeout 剩余预算 clamp。**对 wait 类命令（`wait-until-done`/`wait-for-phase`/`wait-for`），必须设此值且 > flags.timeout（建议 +5s），否则 step 会在命令内部超时前被 runner 杀掉** |
+| `continueOnError` | boolean | 否 | 该步失败是否继续执行后续步骤（默认 false） |
+| `assert` | object | 否 | 对命令输出的断言。key 是字段名，value 是期望值。支持后缀：`_gte`（>=）、`_lte`（<=）、`_contains`（字符串包含） |
+
+#### 执行顺序
+
+```
+setup[0] → setup[1] → ... → steps[0] → steps[1] → ... → teardown[0] → teardown[1] → ...
+```
+
+- `setup` 失败 → 跳过 `steps`，仍执行 `teardown`
+- `steps` 中某步失败（且 `continueOnError` 非 true）→ 跳到 `teardown`
+- `teardown` **始终执行**（即使前面失败了），失败不影响测试 pass/fail，但会作为 `teardown_failure` 出现在 issues 中
+
+### 报告结构
+
+```
+report.json
+├── meta                ← 【第一步读这个】通过率、耗时、是否中断
+│   ├── startTime, endTime, elapsed
+│   ├── totalTests, passed, failed, skipped
+│   ├── config: { testFile, captureSnapshots, retry }
+│   ├── aborted?: boolean
+│   └── abortReason?: string
+│
+├── issues[]            ← 【第二步读这个】失败摘要 + 失败步骤上下文
+│   ├── type: 'test_failure' | 'teardown_failure'
+│   ├── test, testIndex, attempts, error
+│   └── failedStep: { index, phase, cmd, args, error, output, beforeState, afterState, visibleText }
+│
+└── tests[]             ← 【按需深挖】完整记录
+    ├── index, name, status, totalAttempts, maxRetries, elapsed, error
+    ├── attempts[]      ← 每次重试的完整记录（重试历史不丢失）
+    │   ├── attempt, passed, elapsed, error, teardownFailed
+    │   └── steps[]
+    └── steps[]         ← 最后一次 attempt 的步骤（快捷访问）
+        ├── index, phase ('setup'|'step'|'teardown')
+        ├── cmd, args, flags
+        ├── startTime, endTime, elapsed
+        ├── success, error
+        ├── output           ← 命令返回的完整 JSON
+        ├── beforeState      ← 执行前的 status() 快照
+        ├── afterState       ← 执行后的 status() 快照
+        └── visibleText      ← 页面可见文本（仅 UI 变更命令，见下）
+```
+
+**visibleText 触发条件**：仅在以下命令执行后自动采集 `[data-testid=chat-messages]` 区域的可见文本：`send` `type` `switch-session` `switch-model` `switch-provider` `allow-permission` `deny-permission` `open-settings` `close-settings` `new-session` `restart`。其他命令该字段为 `null`。如需手动采集，加一步 `{"cmd": "get-visible-text", "flags": {"selector": "..."}}`。
+
+**beforeState/afterState**：teardown 阶段默认不采集状态快照（减少干扰）。setup 和 step 阶段始终采集（除非 `--no-snapshots`）。
+
+#### AI 读报告的正确姿势
+
+1. **先读 meta** — 知道总体结果（多少通过/失败、是否中断）
+2. **再读 issues** — 知道哪些失败了、什么现象、UI 状态是什么
+3. **按需读 tests[N].steps** — 只读失败测试的具体步骤，看命令返回了什么
+4. **不要全量读 tests 数组** — 通过的测试不需要看细节，避免污染上下文
+
+```bash
+# 读 meta
+node -e "const r=require('.test/runs/<日期>/<主题>/run-001.json'); console.log(JSON.stringify(r.meta, null, 2))"
+
+# 读 issues
+node -e "const r=require('.test/runs/<日期>/<主题>/run-001.json'); console.log(JSON.stringify(r.issues, null, 2))"
+
+# 读特定失败测试的步骤
+node -e "const r=require('.test/runs/<日期>/<主题>/run-001.json'); console.log(JSON.stringify(r.tests[2].steps, null, 2))"
+
+# 跨 suite 汇总分析（自动分类 JS timeout / socket error / 真实 bug）
+python3 .test/scripts/analyze-reports.py .test/runs/<日期目录>
+```
+
+### stdout 输出格式
+
+运行器在 stdout 输出两种 JSON 行（stderr 是日志，stdout 是给程序/AI 消费的）：
+
+**每个测试一行摘要**：
+```json
+{"test":"发送消息","status":"pass","elapsed":3200,"attempts":1}
+{"test":"切换模型","status":"fail","elapsed":30100,"attempts":2,"error":"Step 0 (switch-model) failed: timeout"}
+```
+
+**最终一行总结**：
+```json
+{"_summary":true,"total":10,"passed":8,"failed":2,"skipped":0,"elapsed":45000,"reportPath":"/tmp/report.json","reportWritten":true,"reportWriteError":null,"aborted":false}
+```
+
+### 测试设计模式
+
+#### 模式 1：发送消息并验证回复
+
+```json
+{
+  "name": "发送消息 - 基础",
+  "setup": [{"cmd": "switch-session", "args": ["SESSION_ID"]}],
+  "steps": [
+    {"cmd": "type", "args": ["请只回复两个字：收到"]},
+    {"cmd": "send"},
+    {"cmd": "wait-until-done", "flags": {"timeout": "30000"}, "assert": {"status": "completed"}},
+    {"cmd": "get-messages", "flags": {"last": "2"}, "assert": {"total_gte": 2}},
+    {"cmd": "status", "assert": {"active": false}}
+  ]
+}
+```
+
+#### 模式 2：处理权限请求
+
+`wait-until-done` 遇到权限请求会立即返回 `status: "permission_pending"`，这时执行 `allow-permission` 或 `deny-permission` 放行。
+
+```json
+{
+  "name": "权限请求 - 允许",
+  "setup": [{"cmd": "switch-session", "args": ["SESSION_ID"]}],
+  "steps": [
+    {"cmd": "type", "args": ["请创建一个文件 /tmp/test.txt"]},
+    {"cmd": "send"},
+    {"cmd": "wait-until-done", "flags": {"timeout": "15000"}},
+    {"cmd": "allow-permission"},
+    {"cmd": "wait-until-done", "flags": {"timeout": "30000"}},
+    {"cmd": "get-messages", "flags": {"last": "3"}}
+  ]
+}
+```
+
+#### 模式 3：状态切换压测
+
+```json
+{
+  "name": "快速切换模型",
+  "steps": [
+    {"cmd": "switch-model", "args": ["claude-sonnet-4-6"]},
+    {"cmd": "status"},
+    {"cmd": "switch-model", "args": ["claude-haiku-4-5-20251001"]},
+    {"cmd": "status"},
+    {"cmd": "switch-model", "args": ["claude-opus-4-6"]},
+    {"cmd": "get-current-model"}
+  ]
+}
+```
+
+#### 模式 4：长时间模拟用户操作
+
+```json
+{
+  "name": "多轮对话",
+  "timeout": 180000,
+  "setup": [{"cmd": "switch-session", "args": ["SESSION_ID"]}],
+  "steps": [
+    {"cmd": "type", "args": ["你好"]},
+    {"cmd": "send"},
+    {"cmd": "wait-until-done", "flags": {"timeout": "60000"}},
+    {"cmd": "get-messages", "flags": {"last": "2"}},
+    {"cmd": "type", "args": ["请问你能做什么？"]},
+    {"cmd": "send"},
+    {"cmd": "wait-until-done", "flags": {"timeout": "60000"}},
+    {"cmd": "get-messages", "flags": {"last": "4"}},
+    {"cmd": "get-visible-text", "flags": {"selector": "[data-testid=chat-messages]"}}
+  ],
+  "teardown": [{"cmd": "stop"}]
+}
+```
+
+#### 模式 5：故障恢复
+
+```json
+{
+  "name": "死锁恢复测试",
+  "retry": 1,
+  "steps": [
+    {"cmd": "type", "args": ["test"]},
+    {"cmd": "send"},
+    {"cmd": "wait-until-done", "flags": {"timeout": "5000"}},
+    {"cmd": "status"}
+  ],
+  "teardown": [{"cmd": "stop"}]
+}
+```
+
+#### 模式 6：中断后恢复
+
+验证 stop 能否干净终止 → 状态回到 idle → 第二条消息能否正常完成。
+
+```json
+{
+  "name": "writing阶段中断后发送",
+  "timeout": 90000,
+  "setup": [
+    {"cmd": "new-session", "flags": {"cwd": "/tmp/tokenicode-test"}},
+    {"cmd": "check-editor", "assert": {"hasEditor": true}},
+    {"cmd": "switch-model", "args": ["claude-sonnet-4-6"]}
+  ],
+  "steps": [
+    {"cmd": "type", "args": ["请写一篇3000字的科普文章"]},
+    {"cmd": "send"},
+    {"cmd": "wait-for-phase", "args": ["writing"], "flags": {"timeout": "20000"}, "timeout": 25000},
+    {"cmd": "status", "assert": {"active": true}},
+    {"cmd": "stop"},
+    {"cmd": "status", "assert": {"active": false}},
+    {"cmd": "type", "args": ["请只回复：OK"]},
+    {"cmd": "send"},
+    {"cmd": "wait-until-done", "flags": {"timeout": "60000"}, "assert": {"status": "completed"}, "timeout": 65000},
+    {"cmd": "get-messages", "assert": {"total_gte": 3}}
+  ],
+  "teardown": [{"cmd": "stop", "continueOnError": true}]
+}
+```
+
+要点：`wait-for-phase` 精确等到文本输出再中断；第二条用短回复快速验证；`total_gte: 3` 验证 user1 + user2 + assistant2 都在。
+
+#### 模式 7：对比实验
+
+同一操作只变一个因素（如模型），其他完全相同，一次对比出差异。
+
+```json
+{
+  "tests": [
+    {
+      "name": "sonnet-发送基础消息",
+      "setup": [
+        {"cmd": "new-session", "flags": {"cwd": "/tmp/tokenicode-test"}},
+        {"cmd": "check-editor"},
+        {"cmd": "switch-model", "args": ["claude-sonnet-4-6"]}
+      ],
+      "steps": [
+        {"cmd": "type", "args": ["回复OK"]},
+        {"cmd": "send"},
+        {"cmd": "wait-until-done", "flags": {"timeout": "30000"}, "assert": {"status": "completed"}, "timeout": 35000},
+        {"cmd": "get-messages", "assert": {"total_gte": 2}}
+      ],
+      "teardown": [{"cmd": "stop", "continueOnError": true}]
+    },
+    {
+      "name": "opus-发送基础消息",
+      "setup": [
+        {"cmd": "new-session", "flags": {"cwd": "/tmp/tokenicode-test"}},
+        {"cmd": "check-editor"},
+        {"cmd": "switch-model", "args": ["claude-opus-4-6"]}
+      ],
+      "steps": [
+        {"cmd": "type", "args": ["回复OK"]},
+        {"cmd": "send"},
+        {"cmd": "wait-until-done", "flags": {"timeout": "60000"}, "assert": {"status": "completed"}, "timeout": 65000},
+        {"cmd": "get-messages", "assert": {"total_gte": 2}}
+      ],
+      "teardown": [{"cmd": "stop", "continueOnError": true}]
+    }
+  ]
+}
+```
+
+可扩展变量：不同 prompt 长度、不同 session mode、不同 provider。
+
+### 反模式
+
+1. **不要用 `wait-until-done` 做延时** — `wait-until-done` 超时=步骤失败。要纯等待用 `delay`。
+2. **不要省略 wait-until-done** — 发消息后必须等，否则后续 `get-messages` 拿到的是旧数据。
+3. **不要一步到位** — 拆细步骤，每步做一件事。失败时能精确定位是哪步出问题。
+4. **不要跳过 setup** — 确保测试有明确的起始状态（哪个 session、什么模型）。
+5. **不要忘记 teardown** — 用 `stop` 清理运行中的会话，避免影响下一个测试。teardown 的 stop 加 `"continueOnError": true`，即使没有运行中的会话也不阻塞。
+6. **不要忽略断言** — 步骤 pass 只代表命令没报错，不代表结果正确。用 `assert` 检查关键字段。注意 assert 检查的是**命令返回的 JSON 输出**，不是 beforeState/afterState。
+
+---
+
+## 五、完整端到端示例
+
+```bash
+TKN="node scripts/tokenicode-cli.mjs"
+RUN=".test/runs/$(date +%Y-%m-%d)-my-feature"
+
+# 1. 确认应用在运行
+$TKN ping
+
+# 2. 创建测试时间目录 + suite 定义
+mkdir -p "$RUN" .test/suites/my-feature
+
+# 3. 写测试定义（放 suites/ 下，可跨时间复用）
+cat > .test/suites/my-feature/basic.json << 'EOF'
+{
+  "tests": [
+    {
+      "name": "健康检查",
+      "steps": [{"cmd": "ping"}, {"cmd": "status", "assert": {"active": false}}]
+    },
+    {
+      "name": "发送消息",
+      "setup": [
+        {"cmd": "new-session", "flags": {"cwd": "/tmp/tokenicode-test"}},
+        {"cmd": "check-editor", "assert": {"hasEditor": true}},
+        {"cmd": "switch-model", "args": ["claude-sonnet-4-6"]}
+      ],
+      "steps": [
+        {"cmd": "type", "args": ["请只回复：OK"]},
+        {"cmd": "send"},
+        {"cmd": "wait-until-done", "flags": {"timeout": "30000"}, "assert": {"status": "completed"}, "timeout": 35000},
+        {"cmd": "get-messages", "assert": {"total_gte": 2}}
+      ],
+      "teardown": [{"cmd": "stop", "continueOnError": true}],
+      "retry": 1
+    }
+  ]
+}
+EOF
+
+# 4. 执行（单次，报告输出到时间目录）
+mkdir -p "$RUN/my-feature"
+node scripts/run-tests.mjs .test/suites/my-feature/basic.json --report "$RUN/my-feature/run-001.json"
+
+# 5. 批量执行（20 轮）
+for i in $(seq 1 20); do
+  node scripts/run-tests.mjs .test/suites/my-feature/basic.json \
+    --report "$RUN/my-feature/run-$(printf '%03d' $i).json" \
+    --detail minimal
+done
+
+# 6. 汇总分析
+python3 .test/scripts/analyze-reports.py "$RUN"
+
+# 7. 记录发现（放时间目录下）
+# 在 $RUN/notes-my-feature.md 记录测试结论、踩坑、bug
+```
+
+---
+
+## 六、源码改动
+
+### 新增文件
+
+| 文件 | 行数 | 说明 |
+|------|------|------|
+| `scripts/tokenicode-cli.mjs` | ~530 | CLI 工具主体，30 个命令（含 restart），零外部依赖 |
+| `scripts/run-tests.mjs` | ~550 | 批量测试运行器：串行执行 + Schema 校验 + 自动重试 + 超时硬上限 + 全量记录 + 兜底 restart |
+| `AI-TEST-GUIDE.md` | ~300 | AI 测试编排指南（测试模式参考） |
+| `CLI-TEST-TOOL.md` | 本文件 | 完整文档 |
+
+### 修改文件
+
+#### `src/App.tsx`
+
+在 `useEffect` 中扩展了 `window.__tokenicode_test` 对象（仅 `import.meta.env.DEV` 下生效）：
+
+**新增 import**：
+```typescript
+import { parseSessionMessages } from './lib/session-loader';
+```
+
+**修改 `getMessages()`**（约 195-203 行）：
+- 返回格式从 `Message[]` 改为 `{messages: Message[], total: number}`
+- 新增 `{last?: number, tabId?: string}` 参数支持
+- 默认不截断，CLI 端负责 `--last` 截断
+
+**修改 `getLastMessage()`**（约 205-207 行）：
+- 适配新的 `getMessages` 返回格式
+
+**新增 `status()` 方法**（约 231-249 行）：
+- 一次性返回全局状态快照
+- `active` 字段覆盖四个活跃阶段（thinking/writing/tool/awaiting），比旧的 `isStreaming` 更全面
+- `pendingPermission` 检查 `window.__tokenicode_respond_permission` 是否存在
+
+**新增 `loadSession(sessionId)` 方法**（约 268-338 行）：
+- 完整的 session 加载流程，复刻了 `ConversationList.tsx` 的 `handleLoadSession` 逻辑
+- 路径：保存当前 session 缓存 → 切换 → 尝试缓存恢复 → 磁盘加载 JSONL → parseSessionMessages → 填充消息和 agents
+- 防竞态：异步加载完成后检查 `selectedSessionId` 是否仍是目标 session
+- 三种路径：缓存命中（fast）/ draft session（空）/ 磁盘加载（完整 JSONL 解析）
+
+**关键设计决策**：
+- `loadSession` 是 async 的，但 `execute_js` 不支持 await Promises（序列化为 `{}`）
+- CLI 端使用 per-request ID 的全局变量轮询模式：`window.__tkn_loads[reqId]`
+- 每次 `switch-session` 调用用 `randomUUID().slice(0,8)` 作为 reqId，避免并发冲突
+
+### 未修改的依赖（已有代码）
+
+| 文件 | 作用 |
+|------|------|
+| `src-tauri/Cargo.toml` | 测试通道依赖（`tauri-plugin-mcp`），`cfg(debug_assertions)` 门控 |
+| `src-tauri/src/lib.rs` (`run()` 末尾) | 测试通道注册，在 `/tmp/tokenicode-test.sock` 启动 socket server |
+| `package.json` | 测试通道 npm 包（`tauri-plugin-mcp`，提供前端 event listeners） |
+
+这些是之前 test-harness-bridge 任务的产物，CLI 工具复用了它们提供的 socket 通道。
+
+---
+
+## 七、已知限制
+
+- **HMR 不更新 test helper**：修改 `App.tsx` 后，Vite HMR 不会更新 `useEffect` 闭包。需要 `exec "location.reload()"` 全量刷新 webview。
+- **execute_js 不支持 async**：返回 Promise 的代码会被序列化为 `{}`。`switch-session` 因此使用全局变量 + 轮询模式。
+- **欢迎页没有编辑器**：`new-session` 和 `restart` 后都会停在欢迎页，该页面没有 TipTap 编辑器。`type` 返回 `ok` 但实际无效，`send` 同理。**必须先 `switch-session` 加载一个已有会话**才能进行对话测试。详见「二点五、正确的新会话流程」。
+- **DOM click 对 React 组件无效**：所有交互走 `execute_js` + Zustand store 直操，不走原生点击事件。
+- **relaunch 开新窗口**：`relaunch` 命令 spawn 新进程，会开新 Tauri 窗口。日常测试用 `restart`（同窗口 reload）即可。
+- **relaunch 进程泄漏**：`relaunch` 通过 `lsof` 找 socket 持有者 PID 来杀进程，但旧的 `target/debug/tokenicode` 子进程经常杀不干净。长时间无人值守测试（5 小时）实测累积了 76 个僵尸进程。测试前后手动清理：`pkill -9 -f 'target/debug/tokenicode'`。
+- **tmux 环境缺 cargo**：在 tmux session 中跑 `pnpm tauri dev`（或 relaunch 内部调用）需要先 `source ~/.cargo/env`，否则 `cargo metadata` 报 "No such file or directory"。
+- **Webview 冻结导致 restart 也失效**：restart 依赖 `execute_js` 做 `location.reload()`，webview 冻住时 restart 必然超时。此时只能 relaunch（或手动 `pkill -9` + 重新 `pnpm tauri dev`）。
+
+---
+
+## 八、安全
+
+- Socket server 仅在 `cfg(debug_assertions)` 下编译，release 构建完全不含
+- `data-testid` 属性通过 `import.meta.env.DEV` 门控，production build 自动剥离
+- `window.__tokenicode_test` helper 仅在 `import.meta.env.DEV` 下挂载
+- restart 的进程查找使用 `execFileSync`（无 shell 注入），socket 清理使用 `fs.rmSync`（无路径拼接注入）

--- a/.test/scripts/analyze-reports.py
+++ b/.test/scripts/analyze-reports.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+分析测试报告，汇总每个 suite 的通过率和失败模式。
+
+用法:
+  python3 .test/scripts/analyze-reports.py .test/runs/2026-04-11-full-issue-regression
+  python3 .test/scripts/analyze-reports.py   # 默认扫描最新的 runs/ 子目录
+"""
+import json
+import glob
+import os
+import sys
+from collections import defaultdict
+
+def analyze():
+    # 确定要分析的目录
+    if len(sys.argv) > 1:
+        base = sys.argv[1]
+    else:
+        # 默认：找 .test/runs/ 下最新的子目录
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        runs_dir = os.path.join(script_dir, '..', 'runs')
+        if os.path.isdir(runs_dir):
+            subdirs = sorted([d for d in os.listdir(runs_dir) if os.path.isdir(os.path.join(runs_dir, d))])
+            if subdirs:
+                base = os.path.join(runs_dir, subdirs[-1])
+            else:
+                print("No run directories found in", runs_dir)
+                return
+        else:
+            print("runs/ directory not found")
+            return
+
+    print(f"Analyzing: {base}")
+    print()
+    report_files = sorted(glob.glob(os.path.join(base, '*/run-*.json')))
+
+    if not report_files:
+        print("No reports found.")
+        return
+
+    suite_stats = defaultdict(lambda: {
+        'total_runs': 0,
+        'total_tests': 0,
+        'total_passed': 0,
+        'total_failed': 0,
+        'total_skipped': 0,
+        'failure_map': defaultdict(int),  # test_name -> fail_count
+        'error_patterns': defaultdict(int),  # error_msg -> count
+    })
+
+    for f in report_files:
+        # 从路径中提取 suite 名：.../interrupt-recovery/run-001.json → interrupt-recovery
+        suite_name = os.path.basename(os.path.dirname(f))
+        try:
+            with open(f, 'r') as fh:
+                report = json.load(fh)
+        except (json.JSONDecodeError, IOError):
+            continue
+
+        meta = report.get('meta', {})
+        stats = suite_stats[suite_name]
+        stats['total_runs'] += 1
+        stats['total_tests'] += meta.get('totalTests', 0)
+        stats['total_passed'] += meta.get('passed', 0)
+        stats['total_failed'] += meta.get('failed', 0)
+        stats['total_skipped'] += meta.get('skipped', 0)
+
+        for issue in report.get('issues', []):
+            test_name = issue.get('test', 'unknown')
+            error = issue.get('error', '')
+            issue_type = issue.get('type', '')
+
+            if issue_type == 'test_failure':
+                stats['failure_map'][test_name] += 1
+                # Categorize error
+                if 'Timeout waiting for JS execution' in error:
+                    stats['error_patterns']['JS执行超时(应用无响应)'] += 1
+                elif 'timeout' in error.lower() or 'killed after' in error.lower():
+                    stats['error_patterns']['命令超时'] += 1
+                elif 'assert' in error.lower():
+                    stats['error_patterns']['断言失败'] += 1
+                else:
+                    stats['error_patterns'][error[:80]] += 1
+
+    # 输出汇总
+    print("=" * 70)
+    print("  TOKENICODE 全量测试汇总报告")
+    print("=" * 70)
+    print()
+
+    grand_total = 0
+    grand_passed = 0
+    grand_failed = 0
+
+    for suite_name in sorted(suite_stats.keys()):
+        stats = suite_stats[suite_name]
+        runs = stats['total_runs']
+        total = stats['total_tests']
+        passed = stats['total_passed']
+        failed = stats['total_failed']
+        skipped = stats['total_skipped']
+        rate = (passed / total * 100) if total > 0 else 0
+
+        grand_total += total
+        grand_passed += passed
+        grand_failed += failed
+
+        print(f"┌─ {suite_name}")
+        print(f"│  轮数: {runs}  测试总数: {total}  通过: {passed}  失败: {failed}  跳过: {skipped}")
+        print(f"│  通过率: {rate:.1f}%")
+
+        if stats['failure_map']:
+            print(f"│  失败测试:")
+            for test_name, count in sorted(stats['failure_map'].items(), key=lambda x: -x[1]):
+                print(f"│    - {test_name}: {count}次失败 / {runs}轮")
+
+        if stats['error_patterns']:
+            print(f"│  错误模式:")
+            for pattern, count in sorted(stats['error_patterns'].items(), key=lambda x: -x[1]):
+                print(f"│    - {pattern}: {count}次")
+
+        print(f"└─")
+        print()
+
+    grand_rate = (grand_passed / grand_total * 100) if grand_total > 0 else 0
+    print("=" * 70)
+    print(f"  总计: {grand_total} 测试, {grand_passed} 通过, {grand_failed} 失败")
+    print(f"  整体通过率: {grand_rate:.1f}%")
+    print("=" * 70)
+
+    # 识别间歇性 bug
+    print()
+    print("--- 间歇性失败（部分轮通过部分轮失败）---")
+    for suite_name in sorted(suite_stats.keys()):
+        stats = suite_stats[suite_name]
+        runs = stats['total_runs']
+        for test_name, fail_count in stats['failure_map'].items():
+            if 0 < fail_count < runs:
+                print(f"  {suite_name} / {test_name}: {fail_count}/{runs} 轮失败 ({fail_count/runs*100:.0f}%)")
+
+    print()
+    print("--- 稳定失败（每轮都失败）---")
+    for suite_name in sorted(suite_stats.keys()):
+        stats = suite_stats[suite_name]
+        runs = stats['total_runs']
+        for test_name, fail_count in stats['failure_map'].items():
+            if fail_count >= runs and runs > 1:
+                print(f"  {suite_name} / {test_name}: 全部 {runs} 轮都失败")
+
+if __name__ == '__main__':
+    analyze()

--- a/.test/suites/basic-chat/send-receive.json
+++ b/.test/suites/basic-chat/send-receive.json
@@ -1,0 +1,322 @@
+{
+  "tests": [
+    {
+      "name": "T01-基础发送接收(#57#64回归)",
+      "timeout": 90000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复两个字：收到"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T02-多轮对话消息递增(#28回归)",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：第一轮收到"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：第二轮收到"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 4
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：第三轮收到"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 6
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T03-长回复流式渲染不卡住(#57#64)",
+      "timeout": 120000,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请用300字介绍量子计算的基本原理"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for-phase",
+          "args": [
+            "writing"
+          ],
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "is-streaming"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "90000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 95000
+        },
+        {
+          "cmd": "get-messages",
+          "flags": {
+            "last": "1",
+            "full": true
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T04-空消息不应发送",
+      "timeout": 30000,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "3000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_lte": 0
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/health-and-status/full-health.json
+++ b/.test/suites/health-and-status/full-health.json
@@ -1,0 +1,135 @@
+{
+  "tests": [
+    {
+      "name": "T01-ping连通性",
+      "timeout": 10000,
+      "steps": [
+        {
+          "cmd": "ping",
+          "assert": {
+            "ok": true,
+            "pong": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "T02-status全局状态快照",
+      "timeout": 10000,
+      "steps": [
+        {
+          "cmd": "status",
+          "assert": {
+            "ok": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "T03-query-page-state",
+      "timeout": 15000,
+      "steps": [
+        {
+          "cmd": "query-page",
+          "flags": {
+            "mode": "state"
+          }
+        }
+      ]
+    },
+    {
+      "name": "T04-query-page-info",
+      "timeout": 15000,
+      "steps": [
+        {
+          "cmd": "query-page",
+          "flags": {
+            "mode": "info"
+          }
+        }
+      ]
+    },
+    {
+      "name": "T05-query-page-map-interactive",
+      "timeout": 15000,
+      "steps": [
+        {
+          "cmd": "query-page",
+          "flags": {
+            "mode": "map",
+            "interactive-only": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "T06-check-editor欢迎页无编辑器",
+      "timeout": 10000,
+      "setup": [
+        {
+          "cmd": "new-session"
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "check-editor"
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T07-new-session-with-cwd有编辑器",
+      "timeout": 15000,
+      "steps": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "T08-get-all-sessions返回列表",
+      "timeout": 10000,
+      "steps": [
+        {
+          "cmd": "get-all-sessions"
+        }
+      ]
+    },
+    {
+      "name": "T09-get-current-model返回模型",
+      "timeout": 10000,
+      "steps": [
+        {
+          "cmd": "get-current-model"
+        }
+      ]
+    },
+    {
+      "name": "T10-is-streaming空闲时为false",
+      "timeout": 10000,
+      "steps": [
+        {
+          "cmd": "is-streaming"
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/interrupt-recovery/interrupt-then-send.json
+++ b/.test/suites/interrupt-recovery/interrupt-then-send.json
@@ -1,0 +1,401 @@
+{
+  "tests": [
+    {
+      "name": "T01-writing阶段中断后再发消息(#80核心复现)",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请写一篇3000字的科普文章，主题是人工智能的发展历史"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for-phase",
+          "args": [
+            "writing"
+          ],
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": true
+          }
+        },
+        {
+          "cmd": "stop"
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 3
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T02-thinking阶段中断后再发消息(#80变体)",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请分析一下量子纠缠的哲学意义，写5000字"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for-phase",
+          "args": [
+            "thinking"
+          ],
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "stop"
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：明白"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 3
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T03-连续中断两次再发消息(#80压测)",
+      "timeout": 150000,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "写一篇长文关于宇宙大爆炸"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for-phase",
+          "args": [
+            "writing"
+          ],
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "stop"
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "写一篇长文关于黑洞理论"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for-phase",
+          "args": [
+            "writing"
+          ],
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "stop"
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 5
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T04-stop在非活跃状态不应报错",
+      "timeout": 15000,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/interrupt-recovery/writing-interrupt-then-send.json
+++ b/.test/suites/interrupt-recovery/writing-interrupt-then-send.json
@@ -1,0 +1,206 @@
+{
+  "tests": [
+    {
+      "name": "sonnet-thinking中断后发送(带断言)",
+      "timeout": 90000,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请写一篇2000字关于机器学习的文章"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for",
+          "flags": {
+            "selector": "[data-testid=stop-button]",
+            "timeout": "15000"
+          },
+          "timeout": 20000
+        },
+        {
+          "cmd": "stop"
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false,
+            "phase": "completed"
+          }
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "sonnet-writing中断后发送(带断言+wait-for-phase)",
+      "timeout": 90000,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请写一篇3000字详细介绍相对论的文章，从狭义相对论到广义相对论"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for-phase",
+          "args": [
+            "writing"
+          ],
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": true,
+            "phase": "writing"
+          }
+        },
+        {
+          "cmd": "stop"
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "1000"
+          ]
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 3
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/message-during-stream/msg-while-streaming.json
+++ b/.test/suites/message-during-stream/msg-while-streaming.json
@@ -1,0 +1,252 @@
+{
+  "tests": [
+    {
+      "name": "T01-AI回复中补充消息不丢失(#28)",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请用300字介绍Python编程语言的历史"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for-phase",
+          "args": [
+            "writing"
+          ],
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": true
+          }
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "90000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 95000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T02-Agent运行时编辑器仍可用(#30)",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请列出 /tmp/tokenicode-test 目录下的所有文件"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "allow-permission",
+          "continueOnError": true
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "continueOnError": true,
+          "timeout": 65000
+        },
+        {
+          "cmd": "check-editor"
+        },
+        {
+          "cmd": "status"
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T03-快速连续发两条消息(#28变体)",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：第一条收到"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：第二条收到"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 4
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/model-switching/model-and-provider.json
+++ b/.test/suites/model-switching/model-and-provider.json
@@ -1,0 +1,201 @@
+{
+  "tests": [
+    {
+      "name": "T01-切换到sonnet模型",
+      "timeout": 15000,
+      "steps": [
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        },
+        {
+          "cmd": "get-current-model"
+        },
+        {
+          "cmd": "status"
+        }
+      ]
+    },
+    {
+      "name": "T02-切换到opus模型",
+      "timeout": 15000,
+      "steps": [
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-opus-4-6"
+          ]
+        },
+        {
+          "cmd": "get-current-model"
+        },
+        {
+          "cmd": "status"
+        }
+      ]
+    },
+    {
+      "name": "T03-快速连续切换模型(#45#74压测)",
+      "timeout": 30000,
+      "steps": [
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-opus-4-6"
+          ]
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-opus-4-6"
+          ]
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        },
+        {
+          "cmd": "get-current-model"
+        },
+        {
+          "cmd": "status"
+        }
+      ]
+    },
+    {
+      "name": "T04-切换模型后发消息验证(#74#45)",
+      "timeout": 90000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        },
+        {
+          "cmd": "get-current-model"
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复你的模型名称"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "flags": {
+            "last": "1",
+            "full": true
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T05-获取当前provider",
+      "timeout": 10000,
+      "steps": [
+        {
+          "cmd": "get-current-provider"
+        }
+      ]
+    },
+    {
+      "name": "T06-provider设为null(系统默认)",
+      "timeout": 10000,
+      "steps": [
+        {
+          "cmd": "switch-provider",
+          "args": [
+            "null"
+          ]
+        },
+        {
+          "cmd": "get-current-provider"
+        },
+        {
+          "cmd": "status"
+        }
+      ]
+    },
+    {
+      "name": "T07-模型选择器UI元素存在(#74)",
+      "timeout": 10000,
+      "steps": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "wait-for",
+          "flags": {
+            "selector": "[data-testid=model-selector]",
+            "timeout": "5000"
+          },
+          "timeout": 10000
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/multi-session/tab-switching.json
+++ b/.test/suites/multi-session/tab-switching.json
@@ -1,0 +1,210 @@
+{
+  "tests": [
+    {
+      "name": "T01-创建多个session并切换(#6#58)",
+      "timeout": 30000,
+      "steps": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "get-active-session"
+        },
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "get-active-session"
+        },
+        {
+          "cmd": "get-all-sessions"
+        }
+      ]
+    },
+    {
+      "name": "T02-session间切换保持消息(#49#67回归)",
+      "timeout": 180000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "get-active-session"
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：会话A"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        },
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：会话B"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T03-切换回旧session消息仍在(#67)",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：记住这条"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-active-session"
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        },
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/no-response-filter/early-interrupt.json
+++ b/.test/suites/no-response-filter/early-interrupt.json
@@ -1,0 +1,76 @@
+{
+  "tests": [
+    {
+      "name": "T01-极早打断不应显示No response requested",
+      "timeout": 90000,
+      "retry": 1,
+      "setup": [
+        {"cmd": "new-session", "flags": {"cwd": "/tmp/tokenicode-test"}},
+        {"cmd": "check-editor", "assert": {"hasEditor": true}},
+        {"cmd": "switch-model", "args": ["claude-sonnet-4-6"]}
+      ],
+      "steps": [
+        {"cmd": "type", "args": ["请用5000字详细分析量子力学的哲学意义"]},
+        {"cmd": "send"},
+        {"cmd": "wait-for-phase", "args": ["thinking"], "flags": {"timeout": "60000"}, "timeout": 65000},
+        {"cmd": "delay", "args": ["500"]},
+        {"cmd": "stop"},
+        {"cmd": "delay", "args": ["3000"]},
+        {"cmd": "status", "assert": {"active": false}},
+        {"cmd": "exec", "args": ["(() => { const msgs = window.__tokenicode_test.getMessages({summary: false}).messages; const bad = msgs.filter(m => m.role === 'assistant' && m.type === 'text' && m.content && m.content.includes('No response requested')); return bad.length === 0 ? 'clean' : 'FOUND:' + bad.map(m => m.content.slice(0,80)).join('|'); })()"], "assert": {"result": "clean"}}
+      ],
+      "teardown": [
+        {"cmd": "stop", "continueOnError": true},
+        {"cmd": "delete-session", "continueOnError": true}
+      ]
+    },
+    {
+      "name": "T02-thinking阶段立即打断不应显示No response requested",
+      "timeout": 90000,
+      "retry": 1,
+      "setup": [
+        {"cmd": "new-session", "flags": {"cwd": "/tmp/tokenicode-test"}},
+        {"cmd": "check-editor", "assert": {"hasEditor": true}},
+        {"cmd": "switch-model", "args": ["claude-sonnet-4-6"]}
+      ],
+      "steps": [
+        {"cmd": "type", "args": ["写一篇3000字的科普文章关于黑洞"]},
+        {"cmd": "send"},
+        {"cmd": "wait-for-phase", "args": ["thinking"], "flags": {"timeout": "60000"}, "timeout": 65000},
+        {"cmd": "stop"},
+        {"cmd": "delay", "args": ["3000"]},
+        {"cmd": "status", "assert": {"active": false}},
+        {"cmd": "exec", "args": ["(() => { const msgs = window.__tokenicode_test.getMessages({summary: false}).messages; const bad = msgs.filter(m => m.role === 'assistant' && m.type === 'text' && m.content && m.content.includes('No response requested')); return bad.length === 0 ? 'clean' : 'FOUND:' + bad.map(m => m.content.slice(0,80)).join('|'); })()"], "assert": {"result": "clean"}}
+      ],
+      "teardown": [
+        {"cmd": "stop", "continueOnError": true},
+        {"cmd": "delete-session", "continueOnError": true}
+      ]
+    },
+    {
+      "name": "T03-打断后再发消息-回复不含No response requested",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {"cmd": "new-session", "flags": {"cwd": "/tmp/tokenicode-test"}},
+        {"cmd": "check-editor", "assert": {"hasEditor": true}},
+        {"cmd": "switch-model", "args": ["claude-sonnet-4-6"]}
+      ],
+      "steps": [
+        {"cmd": "type", "args": ["写一篇5000字关于宇宙大爆炸的文章"]},
+        {"cmd": "send"},
+        {"cmd": "wait-for-phase", "args": ["thinking"], "flags": {"timeout": "60000"}, "timeout": 65000},
+        {"cmd": "stop"},
+        {"cmd": "delay", "args": ["2000"]},
+        {"cmd": "type", "args": ["回复OK"]},
+        {"cmd": "send"},
+        {"cmd": "wait-until-done", "flags": {"timeout": "60000"}, "assert": {"status": "completed"}, "timeout": 65000},
+        {"cmd": "exec", "args": ["(() => { const msgs = window.__tokenicode_test.getMessages({summary: false}).messages; const bad = msgs.filter(m => m.role === 'assistant' && m.type === 'text' && m.content && m.content.includes('No response requested')); return bad.length === 0 ? 'clean' : 'FOUND:' + bad.map(m => m.content.slice(0,80)).join('|'); })()"], "assert": {"result": "clean"}}
+      ],
+      "teardown": [
+        {"cmd": "stop", "continueOnError": true},
+        {"cmd": "delete-session", "continueOnError": true}
+      ]
+    }
+  ]
+}

--- a/.test/suites/permission-flow/permission-handling.json
+++ b/.test/suites/permission-flow/permission-handling.json
@@ -1,0 +1,222 @@
+{
+  "tests": [
+    {
+      "name": "T01-触发权限请求并允许(#73)",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请在 /tmp/tokenicode-test/ 目录下创建一个名为 perm-test.txt 的文件，内容写 hello permission test"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "30000"
+          },
+          "timeout": 35000
+        },
+        {
+          "cmd": "status"
+        },
+        {
+          "cmd": "allow-permission",
+          "continueOnError": true
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "allow-permission",
+          "continueOnError": true
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "continueOnError": true,
+          "timeout": 65000
+        },
+        {
+          "cmd": "status"
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T02-权限请求拒绝后继续(#73)",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请在 /tmp/tokenicode-test/ 创建文件 deny-test.txt"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "30000"
+          },
+          "timeout": 35000
+        },
+        {
+          "cmd": "deny-permission",
+          "continueOnError": true
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "continueOnError": true,
+          "timeout": 65000
+        },
+        {
+          "cmd": "status"
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T03-无权限待处理时allow不报错",
+      "timeout": 10000,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "status",
+          "assert": {
+            "pendingPermission": false
+          }
+        },
+        {
+          "cmd": "allow-permission",
+          "continueOnError": true
+        },
+        {
+          "cmd": "status"
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T04-权限UI元素检查",
+      "timeout": 10000,
+      "steps": [
+        {
+          "cmd": "query-page",
+          "flags": {
+            "mode": "map",
+            "interactive-only": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/provider-persistence/provider-revert.json
+++ b/.test/suites/provider-persistence/provider-revert.json
@@ -1,0 +1,416 @@
+{
+  "tests": [
+    {
+      "name": "T01-发消息后provider不回退(#47)",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        },
+        {
+          "cmd": "switch-provider",
+          "args": [
+            "null"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "get-current-provider"
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-current-provider"
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T02-多轮对话后provider不变(#47)",
+      "timeout": 180000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        },
+        {
+          "cmd": "switch-provider",
+          "args": [
+            "null"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "get-current-provider"
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：第一轮OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-current-provider"
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：第二轮OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-current-provider"
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：第三轮OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-current-provider"
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T03-CC-Switch继承配置工作(#7)",
+      "timeout": 90000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        },
+        {
+          "cmd": "switch-provider",
+          "args": [
+            "null"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "get-current-provider"
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：继承配置测试OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T04-切换provider后发消息(#34)",
+      "timeout": 90000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "switch-provider",
+          "args": [
+            "null"
+          ]
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：provider切换测试OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T05-max_tokens无报错(#3)",
+      "timeout": 90000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "flags": {
+            "last": "3",
+            "full": true
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/restart-recovery/restart-tests.json
+++ b/.test/suites/restart-recovery/restart-tests.json
@@ -1,0 +1,47 @@
+{
+  "tests": [
+    {
+      "name": "T01-restart后应用恢复(#66#67)",
+      "timeout": 60000,
+      "steps": [
+        {"cmd": "status"},
+        {"cmd": "restart", "flags": {"timeout": "45000"}},
+        {"cmd": "ping", "assert": {"ok": true}},
+        {"cmd": "status"},
+        {"cmd": "get-all-sessions"}
+      ]
+    },
+    {
+      "name": "T02-restart后session列表保持(#67)",
+      "timeout": 60000,
+      "steps": [
+        {"cmd": "get-all-sessions"},
+        {"cmd": "restart", "flags": {"timeout": "45000"}},
+        {"cmd": "ping", "assert": {"ok": true}},
+        {"cmd": "get-all-sessions"}
+      ]
+    },
+    {
+      "name": "T03-restart后可创建新session",
+      "timeout": 60000,
+      "steps": [
+        {"cmd": "restart", "flags": {"timeout": "45000"}},
+        {"cmd": "ping", "assert": {"ok": true}},
+        {"cmd": "new-session", "flags": {"cwd": "/tmp/tokenicode-test"}},
+        {"cmd": "check-editor", "assert": {"hasEditor": true}},
+        {"cmd": "status"}
+      ]
+    },
+    {
+      "name": "T04-restart后模型设置保持",
+      "timeout": 60000,
+      "steps": [
+        {"cmd": "switch-model", "args": ["claude-opus-4-6"]},
+        {"cmd": "get-current-model"},
+        {"cmd": "restart", "flags": {"timeout": "45000"}},
+        {"cmd": "ping", "assert": {"ok": true}},
+        {"cmd": "get-current-model"}
+      ]
+    }
+  ]
+}

--- a/.test/suites/session-management/session-ops.json
+++ b/.test/suites/session-management/session-ops.json
@@ -1,0 +1,66 @@
+{
+  "tests": [
+    {
+      "name": "T01-获取所有session列表(#67#24)",
+      "timeout": 15000,
+      "steps": [
+        {"cmd": "get-all-sessions"}
+      ]
+    },
+    {
+      "name": "T02-获取活跃session",
+      "timeout": 10000,
+      "steps": [
+        {"cmd": "get-active-session"}
+      ]
+    },
+    {
+      "name": "T03-新建session无cwd到欢迎页",
+      "timeout": 15000,
+      "steps": [
+        {"cmd": "new-session"},
+        {"cmd": "delay", "args": ["2000"]},
+        {"cmd": "check-editor"},
+        {"cmd": "status"}
+      ]
+    },
+    {
+      "name": "T04-新建session有cwd到编辑器",
+      "timeout": 15000,
+      "steps": [
+        {"cmd": "new-session", "flags": {"cwd": "/tmp/tokenicode-test"}},
+        {"cmd": "check-editor", "assert": {"hasEditor": true}},
+        {"cmd": "status"}
+      ]
+    },
+    {
+      "name": "T05-切换到已有session(#38#63)",
+      "timeout": 60000,
+      "steps": [
+        {"cmd": "get-all-sessions"},
+        {"cmd": "new-session", "flags": {"cwd": "/tmp/tokenicode-test"}},
+        {"cmd": "get-active-session"},
+        {"cmd": "new-session", "flags": {"cwd": "/tmp/tokenicode-test"}},
+        {"cmd": "delay", "args": ["2000"]},
+        {"cmd": "get-active-session"}
+      ]
+    },
+    {
+      "name": "T06-session计数一致性(#32)",
+      "timeout": 15000,
+      "steps": [
+        {"cmd": "status"},
+        {"cmd": "get-all-sessions"}
+      ]
+    },
+    {
+      "name": "T07-新session后消息为空",
+      "timeout": 15000,
+      "steps": [
+        {"cmd": "new-session", "flags": {"cwd": "/tmp/tokenicode-test"}},
+        {"cmd": "check-editor", "assert": {"hasEditor": true}},
+        {"cmd": "get-messages", "assert": {"total_lte": 0}}
+      ]
+    }
+  ]
+}

--- a/.test/suites/settings-panel/settings-operations.json
+++ b/.test/suites/settings-panel/settings-operations.json
@@ -1,0 +1,291 @@
+{
+  "tests": [
+    {
+      "name": "T01-打开关闭设置面板",
+      "timeout": 15000,
+      "steps": [
+        {
+          "cmd": "open-settings"
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "settingsOpen": true
+          }
+        },
+        {
+          "cmd": "wait-for",
+          "flags": {
+            "selector": "[data-testid=settings-panel]",
+            "timeout": "5000"
+          },
+          "timeout": 10000
+        },
+        {
+          "cmd": "close-settings"
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "settingsOpen": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "T02-设置tab切换-general",
+      "timeout": 15000,
+      "steps": [
+        {
+          "cmd": "open-settings"
+        },
+        {
+          "cmd": "switch-settings-tab",
+          "args": [
+            "general"
+          ]
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "1000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "settingsOpen": true
+          }
+        },
+        {
+          "cmd": "close-settings"
+        }
+      ]
+    },
+    {
+      "name": "T03-设置tab切换-provider(#75)",
+      "timeout": 15000,
+      "steps": [
+        {
+          "cmd": "open-settings"
+        },
+        {
+          "cmd": "switch-settings-tab",
+          "args": [
+            "provider"
+          ]
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "1000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "settingsOpen": true
+          }
+        },
+        {
+          "cmd": "close-settings"
+        }
+      ]
+    },
+    {
+      "name": "T04-设置tab切换-cli(#79)",
+      "timeout": 15000,
+      "steps": [
+        {
+          "cmd": "open-settings"
+        },
+        {
+          "cmd": "switch-settings-tab",
+          "args": [
+            "cli"
+          ]
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "1000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "settingsOpen": true
+          }
+        },
+        {
+          "cmd": "close-settings"
+        }
+      ]
+    },
+    {
+      "name": "T05-设置tab切换-mcp(#53)",
+      "timeout": 15000,
+      "steps": [
+        {
+          "cmd": "open-settings"
+        },
+        {
+          "cmd": "switch-settings-tab",
+          "args": [
+            "mcp"
+          ]
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "1000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "settingsOpen": true
+          }
+        },
+        {
+          "cmd": "close-settings"
+        }
+      ]
+    },
+    {
+      "name": "T06-快速切换所有tab",
+      "timeout": 30000,
+      "steps": [
+        {
+          "cmd": "open-settings"
+        },
+        {
+          "cmd": "switch-settings-tab",
+          "args": [
+            "general"
+          ]
+        },
+        {
+          "cmd": "switch-settings-tab",
+          "args": [
+            "provider"
+          ]
+        },
+        {
+          "cmd": "switch-settings-tab",
+          "args": [
+            "cli"
+          ]
+        },
+        {
+          "cmd": "switch-settings-tab",
+          "args": [
+            "mcp"
+          ]
+        },
+        {
+          "cmd": "switch-settings-tab",
+          "args": [
+            "general"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "settingsOpen": true
+          }
+        },
+        {
+          "cmd": "close-settings"
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "settingsOpen": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "T07-设置面板打开时发消息",
+      "timeout": 60000,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "open-settings"
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "settingsOpen": true
+          }
+        },
+        {
+          "cmd": "close-settings"
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "settingsOpen": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "close-settings",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T08-provider-card存在性检查(#75)",
+      "timeout": 15000,
+      "steps": [
+        {
+          "cmd": "open-settings"
+        },
+        {
+          "cmd": "switch-settings-tab",
+          "args": [
+            "provider"
+          ]
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "1000"
+          ]
+        },
+        {
+          "cmd": "query-page",
+          "flags": {
+            "mode": "map",
+            "interactive-only": true
+          }
+        },
+        {
+          "cmd": "close-settings"
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/slash-commands/command-recognition.json
+++ b/.test/suites/slash-commands/command-recognition.json
@@ -1,0 +1,196 @@
+{
+  "tests": [
+    {
+      "name": "T01-斜杠命令/help发送(#65回归)",
+      "timeout": 90000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "/help"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 1
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T02-斜杠命令/model发送",
+      "timeout": 90000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "/model"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "status"
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T03-普通文本不触发命令(#65)",
+      "timeout": 90000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "这不是一个斜杠命令，请回复OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/stdinid-race-fix/basic-regression.json
+++ b/.test/suites/stdinid-race-fix/basic-regression.json
@@ -1,0 +1,165 @@
+{
+  "tests": [
+    {
+      "name": "T01-基础发送接收无回归",
+      "timeout": 90000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复两个字：收到"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T02-多轮对话消息递增无回归",
+      "timeout": 150000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：第一轮收到"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：第二轮收到"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 4
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/stdinid-race-fix/empty-message.json
+++ b/.test/suites/stdinid-race-fix/empty-message.json
@@ -1,0 +1,138 @@
+{
+  "tests": [
+    {
+      "name": "T01-空消息不应发送",
+      "timeout": 30000,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "3000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_lte": 0
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T02-正常消息发送后空消息不应追加",
+      "timeout": 90000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：收到"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "3000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_lte": 3
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/stdinid-race-fix/full-validation.json
+++ b/.test/suites/stdinid-race-fix/full-validation.json
@@ -1,0 +1,489 @@
+{
+  "tests": [
+    {
+      "name": "T01-基础发送接收",
+      "timeout": 90000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "回复OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "3000"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "T02-多轮对话(同session复用stdin)",
+      "timeout": 150000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "回复OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "回复OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 4
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "3000"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "T03-空消息不应发送",
+      "timeout": 30000,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "3000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_lte": 0
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "3000"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "T04-writing阶段stop后再发消息",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请写一篇3000字的科普文章，主题是人工智能的发展历史"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for-phase",
+          "args": [
+            "writing"
+          ],
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "stop"
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "回复OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 3
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "3000"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "T05-连续stop两次再发消息",
+      "timeout": 180000,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "写一篇长文关于宇宙大爆炸"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for-phase",
+          "args": [
+            "writing"
+          ],
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "stop"
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "写一篇长文关于黑洞理论"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for-phase",
+          "args": [
+            "writing"
+          ],
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "stop"
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "回复OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 5
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "3000"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/stdinid-race-fix/interrupt-recovery.json
+++ b/.test/suites/stdinid-race-fix/interrupt-recovery.json
@@ -1,0 +1,343 @@
+{
+  "tests": [
+    {
+      "name": "T01-thinking阶段stop后再发消息应收到回复",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请写一篇5000字的文章关于量子计算"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for-phase",
+          "args": [
+            "thinking"
+          ],
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "stop"
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 3
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T02-writing阶段stop后再发消息应收到回复",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请写一篇3000字的科普文章，主题是人工智能的发展历史"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for-phase",
+          "args": [
+            "writing"
+          ],
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "stop"
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：明白"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 3
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T03-连续stop两次再发消息应收到回复",
+      "timeout": 180000,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "写一篇长文关于宇宙大爆炸"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for-phase",
+          "args": [
+            "writing"
+          ],
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "stop"
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "写一篇长文关于黑洞理论"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for-phase",
+          "args": [
+            "writing"
+          ],
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "stop"
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "请只回复：OK"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 5
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/streaming-stress/stream-stall.json
+++ b/.test/suites/streaming-stress/stream-stall.json
@@ -1,0 +1,279 @@
+{
+  "tests": [
+    {
+      "name": "T01-长回复流式不卡住(#57#64)",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请用500字详细介绍太阳系的八大行星，每个行星至少50字"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-for-phase",
+          "args": [
+            "writing"
+          ],
+          "flags": {
+            "timeout": "60000"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "is-streaming"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "90000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 95000
+        },
+        {
+          "cmd": "get-messages",
+          "flags": {
+            "last": "1",
+            "full": true
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T02-连续三条消息流式完整(#57#64)",
+      "timeout": 240000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "用200字介绍地球"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 2
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "用200字介绍火星"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 4
+          }
+        },
+        {
+          "cmd": "type",
+          "args": [
+            "用200字介绍木星"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "assert": {
+            "total_gte": 6
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T03-thinking后writing完整输出(#57)",
+      "timeout": 120000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请深度思考一下：1+1为什么等于2？用100字回答"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "90000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 95000
+        },
+        {
+          "cmd": "get-messages",
+          "flags": {
+            "last": "2",
+            "full": true
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    }
+  ]
+}

--- a/.test/suites/ui-state-checks/ui-elements.json
+++ b/.test/suites/ui-state-checks/ui-elements.json
@@ -1,0 +1,360 @@
+{
+  "tests": [
+    {
+      "name": "T01-CLI管理页版本显示(#29#37#10#16)",
+      "timeout": 20000,
+      "steps": [
+        {
+          "cmd": "open-settings"
+        },
+        {
+          "cmd": "switch-settings-tab",
+          "args": [
+            "cli"
+          ]
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "get-visible-text",
+          "flags": {
+            "selector": "[data-testid=settings-panel]"
+          }
+        },
+        {
+          "cmd": "close-settings"
+        }
+      ]
+    },
+    {
+      "name": "T02-MCP面板加载(#53#25#33)",
+      "timeout": 20000,
+      "steps": [
+        {
+          "cmd": "open-settings"
+        },
+        {
+          "cmd": "switch-settings-tab",
+          "args": [
+            "mcp"
+          ]
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "get-visible-text",
+          "flags": {
+            "selector": "[data-testid=settings-panel]"
+          }
+        },
+        {
+          "cmd": "close-settings"
+        }
+      ]
+    },
+    {
+      "name": "T03-Provider面板Add按钮(#75)",
+      "timeout": 20000,
+      "steps": [
+        {
+          "cmd": "open-settings"
+        },
+        {
+          "cmd": "switch-settings-tab",
+          "args": [
+            "provider"
+          ]
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "query-page",
+          "flags": {
+            "mode": "map",
+            "interactive-only": true
+          }
+        },
+        {
+          "cmd": "close-settings"
+        }
+      ]
+    },
+    {
+      "name": "T04-Provider预设检查(#14#21)",
+      "timeout": 20000,
+      "steps": [
+        {
+          "cmd": "open-settings"
+        },
+        {
+          "cmd": "switch-settings-tab",
+          "args": [
+            "provider"
+          ]
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "get-visible-text",
+          "flags": {
+            "selector": "[data-testid=settings-panel]"
+          }
+        },
+        {
+          "cmd": "close-settings"
+        }
+      ]
+    },
+    {
+      "name": "T05-General设置页面(#15#73)",
+      "timeout": 20000,
+      "steps": [
+        {
+          "cmd": "open-settings"
+        },
+        {
+          "cmd": "switch-settings-tab",
+          "args": [
+            "general"
+          ]
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "2000"
+          ]
+        },
+        {
+          "cmd": "get-visible-text",
+          "flags": {
+            "selector": "[data-testid=settings-panel]"
+          }
+        },
+        {
+          "cmd": "close-settings"
+        }
+      ]
+    },
+    {
+      "name": "T06-模型选择器列表(#23#11)",
+      "timeout": 20000,
+      "steps": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "wait-for",
+          "flags": {
+            "selector": "[data-testid=model-selector]",
+            "timeout": "5000"
+          },
+          "timeout": 10000
+        },
+        {
+          "cmd": "query-page",
+          "flags": {
+            "mode": "map",
+            "interactive-only": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "T07-双击ESC不触发回退(#36)",
+      "timeout": 15000,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "exec",
+          "args": [
+            "(() => { const e1 = new KeyboardEvent('keydown', {key:'Escape',code:'Escape',bubbles:true}); document.dispatchEvent(e1); setTimeout(() => { const e2 = new KeyboardEvent('keydown', {key:'Escape',code:'Escape',bubbles:true}); document.dispatchEvent(e2); }, 200); return 'dispatched'; })()"
+          ]
+        },
+        {
+          "cmd": "delay",
+          "args": [
+            "1000"
+          ]
+        },
+        {
+          "cmd": "query-page",
+          "flags": {
+            "mode": "map",
+            "interactive-only": true
+          }
+        },
+        {
+          "cmd": "status"
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T08-Markdown加粗中文渲染(#19)",
+      "timeout": 90000,
+      "retry": 1,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "switch-model",
+          "args": [
+            "claude-sonnet-4-6"
+          ]
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请在回复中使用markdown加粗格式，输出这句话：**「测试」**是**（重要的）**。只输出这句话，不要其他内容"
+          ]
+        },
+        {
+          "cmd": "send"
+        },
+        {
+          "cmd": "wait-until-done",
+          "flags": {
+            "timeout": "60000"
+          },
+          "assert": {
+            "status": "completed"
+          },
+          "timeout": 65000
+        },
+        {
+          "cmd": "get-messages",
+          "flags": {
+            "last": "1",
+            "full": true
+          }
+        },
+        {
+          "cmd": "status",
+          "assert": {
+            "active": false
+          }
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T09-.md路径不触发URL(#62)",
+      "timeout": 15000,
+      "setup": [
+        {
+          "cmd": "new-session",
+          "flags": {
+            "cwd": "/tmp/tokenicode-test"
+          }
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        }
+      ],
+      "steps": [
+        {
+          "cmd": "type",
+          "args": [
+            "请读取文件 /tmp/test/README.md 和 /tmp/test/CHANGELOG.md"
+          ]
+        },
+        {
+          "cmd": "check-editor",
+          "assert": {
+            "hasEditor": true
+          }
+        },
+        {
+          "cmd": "status"
+        }
+      ],
+      "teardown": [
+        {
+          "cmd": "stop",
+          "continueOnError": true
+        },
+        {
+          "cmd": "delete-session",
+          "continueOnError": true
+        }
+      ]
+    },
+    {
+      "name": "T10-环境变量DISABLE_BETAS(#69)",
+      "timeout": 20000,
+      "steps": [
+        {
+          "cmd": "exec",
+          "args": [
+            "JSON.stringify({env: window.__tokenicode_test ? 'test_helper_exists' : 'no_helper'})"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.0",
+    "tauri-plugin-mcp": "^0.1.0",
     "@tiptap/extension-hard-break": "^3.20.0",
     "@tiptap/extension-placeholder": "^3.20.0",
     "@tiptap/pm": "^3.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      tauri-plugin-mcp:
+        specifier: ^0.1.0
+        version: 0.1.0
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.13)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -1904,6 +1907,9 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  tauri-plugin-mcp@0.1.0:
+    resolution: {integrity: sha512-deml377Ax032+AabqGc5wkhJygn6XtOggqTWPVNIQ8DUksFRdy2cvX1xZWF7xLG3dO0QUBt/P7CRyJ3IRNV+0w==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4177,6 +4183,10 @@ snapshots:
   tailwindcss@4.1.18: {}
 
   tapable@2.3.0: {}
+
+  tauri-plugin-mcp@0.1.0:
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   tinybench@2.9.0: {}
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,646 @@
+#!/usr/bin/env node
+
+// run-tests.mjs — Mechanical test runner for TOKENICODE GUI
+// Reads test definitions from JSON, executes them serially via tokenicode-cli.mjs,
+// records everything, outputs structured report.
+// Zero external dependencies — Node.js built-in modules only.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = resolve(__dirname, 'tokenicode-cli.mjs');
+const DEFAULT_STEP_TIMEOUT = 30_000;  // 30s per step
+const DEFAULT_TEST_TIMEOUT = 120_000; // 2 min per test
+const MAX_CONSECUTIVE_FAILURES = 3;   // trigger restart after this many
+const REPORT_DIR = process.env.TOKENICODE_REPORT_DIR || '/tmp';
+const DETAIL_LEVELS = { minimal: 0, standard: 1, full: 2 };
+
+// ─── CLI Bridge ──────────────────────────────────────────────────────────────
+
+/**
+ * Execute a single CLI command. Returns the parsed JSON output.
+ * This is the ONLY interface to TOKENICODE — pure process spawn, no socket.
+ */
+function cli(cmd, args = [], flags = {}, timeout = DEFAULT_STEP_TIMEOUT) {
+  const argv = [CLI_PATH, cmd, ...args];
+  for (const [k, v] of Object.entries(flags)) {
+    argv.push(`--${k}`);
+    if (v !== true) argv.push(String(v));
+  }
+
+  const start = Date.now();
+  try {
+    const stdout = execFileSync('node', argv, {
+      encoding: 'utf8',
+      timeout,
+      maxBuffer: 10 * 1024 * 1024, // 10MB for large outputs
+      env: { ...process.env },
+    });
+    const elapsed = Date.now() - start;
+    const lines = stdout.trim().split('\n').filter(Boolean);
+    const lastLine = lines[lines.length - 1] || '{}';
+    try {
+      return { ...JSON.parse(lastLine), _elapsed: elapsed };
+    } catch {
+      return { ok: false, error: `Unparseable CLI output: ${lastLine.slice(0, 200)}`, _elapsed: elapsed };
+    }
+  } catch (err) {
+    const elapsed = Date.now() - start;
+    if (err.killed || err.signal === 'SIGTERM') {
+      return { ok: false, error: `Command '${cmd}' killed after ${timeout}ms timeout`, _elapsed: elapsed };
+    }
+    const stdout = (err.stdout || '').trim();
+    if (stdout) {
+      try {
+        return { ...JSON.parse(stdout), _elapsed: elapsed };
+      } catch { /* fall through */ }
+    }
+    return { ok: false, error: err.message?.slice(0, 500) || 'Unknown CLI error', _elapsed: elapsed };
+  }
+}
+
+/**
+ * Capture a status snapshot (lightweight, for recording state transitions).
+ */
+function captureState() {
+  try {
+    const result = cli('status', [], {}, 8000);
+    if (result.ok) {
+      const { ok, _elapsed, ...state } = result;
+      return state;
+    }
+    return { error: result.error };
+  } catch {
+    return { error: 'status capture failed' };
+  }
+}
+
+/**
+ * Capture visible text from a selector (for recording what the user would see).
+ */
+function captureVisibleText(selector = '[data-testid=chat-messages]') {
+  try {
+    const result = cli('get-visible-text', [], { selector }, 8000);
+    if (result.ok && result.text) {
+      const text = result.text.length > 2000 ? result.text.slice(0, 2000) + '…[truncated]' : result.text;
+      return text;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Schema Validation ───────────────────────────────────────────────────────
+
+/**
+ * Validate a step array (steps/setup/teardown). Returns error string or null.
+ */
+function validateStepArray(steps, testIndex, testName, arrayName) {
+  if (!Array.isArray(steps)) {
+    return `Test ${testIndex} ("${testName}"): "${arrayName}" must be an array`;
+  }
+  for (let i = 0; i < steps.length; i++) {
+    const s = steps[i];
+    if (!s || typeof s !== 'object' || typeof s.cmd !== 'string') {
+      return `Test ${testIndex} ${arrayName}[${i}]: must be an object with a "cmd" string`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Validate a single test definition. Returns null if valid, error string if invalid.
+ */
+function validateTestDef(testDef, index) {
+  if (!testDef || typeof testDef !== 'object') {
+    return `Test ${index}: must be an object`;
+  }
+  const name = testDef.name || 'unnamed';
+  if (!Array.isArray(testDef.steps)) {
+    return `Test ${index} ("${name}"): "steps" must be an array`;
+  }
+  if (testDef.steps.length === 0) {
+    return `Test ${index} ("${name}"): "steps" must not be empty`;
+  }
+  // Validate steps, setup, and teardown elements
+  const stepsErr = validateStepArray(testDef.steps, index, name, 'steps');
+  if (stepsErr) return stepsErr;
+  if (testDef.setup) {
+    const setupErr = validateStepArray(testDef.setup, index, name, 'setup');
+    if (setupErr) return setupErr;
+  }
+  if (testDef.teardown) {
+    const teardownErr = validateStepArray(testDef.teardown, index, name, 'teardown');
+    if (teardownErr) return teardownErr;
+  }
+  return null;
+}
+
+// ─── Test Executor ───────────────────────────────────────────────────────────
+
+/**
+ * Execute a single test step. Returns a detailed step record.
+ * @param {number} remainingBudgetMs - remaining time budget from test timeout (for clamping)
+ */
+function executeStep(step, stepIndex, phase, captureSnapshots, remainingBudgetMs, detailLevel = 'standard') {
+  const record = {
+    index: stepIndex,
+    phase, // 'setup' | 'step' | 'teardown'
+    cmd: step.cmd,
+    args: step.args || [],
+    flags: step.flags || {},
+    startTime: new Date().toISOString(),
+    success: false,
+    output: null,
+    error: null,
+    elapsed: 0,
+    beforeState: null,
+    afterState: null,
+    visibleText: null,
+  };
+
+  // Pre-step state snapshot (skipped in minimal mode)
+  if (captureSnapshots && detailLevel !== 'minimal') {
+    record.beforeState = captureState();
+  }
+
+  // Clamp step timeout to remaining test budget (testTimeout is a hard limit)
+  const stepTimeout = step.timeout || DEFAULT_STEP_TIMEOUT;
+  let effectiveTimeout;
+  if (remainingBudgetMs != null) {
+    if (phase === 'teardown') {
+      // Teardown gets at least 3s to clean up, even if test budget is exhausted
+      effectiveTimeout = Math.min(stepTimeout, Math.max(remainingBudgetMs, 3000));
+    } else {
+      // Setup and test steps are strictly clamped. If budget is exhausted, skip.
+      effectiveTimeout = Math.min(stepTimeout, Math.max(remainingBudgetMs, 0));
+      if (effectiveTimeout <= 0) {
+        record.error = 'Test timeout budget exhausted';
+        record.endTime = new Date().toISOString();
+        return record;
+      }
+    }
+  } else {
+    effectiveTimeout = stepTimeout;
+  }
+
+  const result = cli(step.cmd, step.args || [], step.flags || {}, effectiveTimeout);
+  record.elapsed = result._elapsed || 0;
+  record.output = result;
+  record.success = !!result.ok;
+  if (!result.ok) {
+    record.error = result.error || 'Command returned ok:false';
+  }
+
+  // Step-level assertions: check output fields against expected values.
+  // Supports exact match (key), gte (key_gte), lte (key_lte), contains (key_contains).
+  if (step.assert && typeof step.assert === 'object' && record.success) {
+    const assertErrors = [];
+    for (const [key, expected] of Object.entries(step.assert)) {
+      let field, cmp;
+      if (key.endsWith('_gte'))           { field = key.slice(0, -4); cmp = 'gte'; }
+      else if (key.endsWith('_lte'))      { field = key.slice(0, -4); cmp = 'lte'; }
+      else if (key.endsWith('_contains')) { field = key.slice(0, -9); cmp = 'contains'; }
+      else                                { field = key; cmp = 'eq'; }
+      const actual = result[field];
+      let passed;
+      switch (cmp) {
+        case 'eq':       passed = actual === expected; break;
+        case 'gte':      passed = actual >= expected; break;
+        case 'lte':      passed = actual <= expected; break;
+        case 'contains': passed = typeof actual === 'string' && actual.includes(String(expected)); break;
+      }
+      if (!passed) assertErrors.push(`${key}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    }
+    if (assertErrors.length) {
+      record.success = false;
+      record.error = `Assertion failed: ${assertErrors.join('; ')}`;
+    }
+  }
+
+  // Post-step state snapshot + visible text for UI-changing commands
+  // Detail levels: minimal (no snapshots), standard (state snapshots), full (snapshots + visible text always)
+  if (captureSnapshots && detailLevel !== 'minimal') {
+    record.afterState = captureState();
+    if (detailLevel === 'full') {
+      // Full: capture visible text on every step
+      record.visibleText = captureVisibleText();
+    } else {
+      // Standard: capture visible text only for UI-changing commands
+      const uiChangingCmds = new Set(['send', 'type', 'switch-session', 'switch-model', 'switch-provider',
+        'allow-permission', 'deny-permission', 'open-settings', 'close-settings', 'new-session', 'restart']);
+      if (uiChangingCmds.has(step.cmd)) {
+        record.visibleText = captureVisibleText();
+      }
+    }
+  }
+
+  record.endTime = new Date().toISOString();
+  return record;
+}
+
+/**
+ * Execute a single test (all its steps). Returns a test record.
+ * Handles retries at the test level. All attempt histories are preserved.
+ */
+function executeTest(testDef, testIndex, globalConfig) {
+  const maxRetries = testDef.retry ?? globalConfig.retry ?? 0;
+  const captureSnapshots = testDef.captureSnapshots ?? globalConfig.captureSnapshots ?? true;
+  const testTimeout = testDef.timeout || globalConfig.testTimeout || DEFAULT_TEST_TIMEOUT;
+  const detailLevel = globalConfig.detailLevel || 'standard';
+
+  const testRecord = {
+    index: testIndex,
+    name: testDef.name || `Test ${testIndex + 1}`,
+    status: 'pending',
+    totalAttempts: 0,
+    maxRetries,
+    elapsed: 0,
+    // All attempt histories are preserved (fixes "retry history lost" issue)
+    attempts: [],
+    // steps = the final (last) attempt's steps (for backwards compatibility)
+    steps: [],
+    error: null,
+    startTime: new Date().toISOString(),
+    endTime: null,
+  };
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    testRecord.totalAttempts = attempt + 1;
+    const testStart = Date.now();
+    const stepRecords = [];
+    let testPassed = true;
+    let aborted = false;
+    let attemptError = null;
+
+    // Run setup steps (if any)
+    if (testDef.setup) {
+      for (let i = 0; i < testDef.setup.length; i++) {
+        const remaining = testTimeout - (Date.now() - testStart);
+        const setupRecord = executeStep(testDef.setup[i], i, 'setup', captureSnapshots, remaining, detailLevel);
+        stepRecords.push(setupRecord);
+        if (!setupRecord.success) {
+          attemptError = `Setup step ${i} failed: ${setupRecord.error}`;
+          testPassed = false;
+          break;
+        }
+      }
+    }
+
+    // Run test steps
+    if (testPassed) {
+      for (let i = 0; i < testDef.steps.length; i++) {
+        const elapsed = Date.now() - testStart;
+        if (elapsed > testTimeout) {
+          attemptError = `Test timed out after ${testTimeout}ms at step ${i}`;
+          testPassed = false;
+          aborted = true;
+          break;
+        }
+
+        const remaining = testTimeout - elapsed;
+        const stepRecord = executeStep(testDef.steps[i], i, 'step', captureSnapshots, remaining, detailLevel);
+        stepRecords.push(stepRecord);
+
+        if (!stepRecord.success && !testDef.steps[i].continueOnError) {
+          attemptError = `Step ${i} (${testDef.steps[i].cmd}) failed: ${stepRecord.error}`;
+          testPassed = false;
+          break;
+        }
+      }
+    }
+
+    // Run teardown steps (always run, even on failure)
+    let teardownFailed = false;
+    if (testDef.teardown) {
+      for (let i = 0; i < testDef.teardown.length; i++) {
+        const remaining = testTimeout - (Date.now() - testStart);
+        const teardownRecord = executeStep(testDef.teardown[i], i, 'teardown', false, remaining, detailLevel);
+        stepRecords.push(teardownRecord);
+        if (!teardownRecord.success) teardownFailed = true;
+      }
+    }
+
+    const attemptRecord = {
+      attempt: attempt + 1,
+      passed: testPassed,
+      elapsed: Date.now() - testStart,
+      error: attemptError,
+      teardownFailed,
+      steps: stepRecords,
+    };
+    testRecord.attempts.push(attemptRecord);
+
+    if (testPassed) {
+      testRecord.status = 'pass';
+      testRecord.error = null; // Clear error from previous attempts
+      testRecord.steps = stepRecords;
+      testRecord.elapsed = attemptRecord.elapsed;
+      break;
+    }
+
+    if (aborted) {
+      testRecord.status = 'fail';
+      testRecord.error = attemptError;
+      testRecord.steps = stepRecords;
+      testRecord.elapsed = attemptRecord.elapsed;
+      break;
+    }
+
+    // If we have more retries, log and continue
+    if (attempt < maxRetries) {
+      process.stderr.write(`[run-tests] Test "${testRecord.name}" attempt ${attempt + 1} failed, retrying...\n`);
+    } else {
+      testRecord.status = 'fail';
+      testRecord.error = attemptError;
+      testRecord.steps = stepRecords;
+      testRecord.elapsed = attemptRecord.elapsed;
+    }
+  }
+
+  testRecord.endTime = new Date().toISOString();
+  return testRecord;
+}
+
+// ─── Report Builder ──────────────────────────────────────────────────────────
+
+function buildReport(testRecords, config, startTime) {
+  const endTime = new Date();
+  const passed = testRecords.filter(t => t.status === 'pass').length;
+  const failed = testRecords.filter(t => t.status === 'fail').length;
+  const skipped = testRecords.filter(t => t.status === 'skipped').length;
+
+  // Extract issues: failed tests + tests where teardown failed (even if test passed)
+  const issues = [];
+  for (const t of testRecords) {
+    if (t.status === 'fail') {
+      const failStep = t.steps.find(s => !s.success);
+      issues.push({
+        test: t.name,
+        testIndex: t.index,
+        type: 'test_failure',
+        attempts: t.totalAttempts,
+        error: t.error,
+        failedStep: failStep ? {
+          index: failStep.index,
+          phase: failStep.phase,
+          cmd: failStep.cmd,
+          args: failStep.args,
+          error: failStep.error,
+          output: failStep.output,
+          beforeState: failStep.beforeState,
+          afterState: failStep.afterState,
+          visibleText: failStep.visibleText,
+        } : null,
+      });
+    }
+    // Also report teardown failures (state pollution risk for subsequent tests)
+    const lastAttempt = t.attempts?.[t.attempts.length - 1];
+    if (lastAttempt?.teardownFailed) {
+      const teardownFail = lastAttempt.steps.find(s => s.phase === 'teardown' && !s.success);
+      if (teardownFail) {
+        issues.push({
+          test: t.name,
+          testIndex: t.index,
+          type: 'teardown_failure',
+          error: `Teardown failed: ${teardownFail.error}`,
+          failedStep: {
+            index: teardownFail.index,
+            phase: 'teardown',
+            cmd: teardownFail.cmd,
+            args: teardownFail.args,
+            error: teardownFail.error,
+            output: teardownFail.output,
+          },
+        });
+      }
+    }
+  }
+
+  return {
+    meta: {
+      startTime: startTime.toISOString(),
+      endTime: endTime.toISOString(),
+      elapsed: endTime - startTime,
+      totalTests: testRecords.length,
+      passed,
+      failed,
+      skipped,
+      config: {
+        testFile: config._testFile || null,
+        captureSnapshots: config.captureSnapshots ?? true,
+        retry: config.retry ?? 0,
+      },
+    },
+    issues,
+    tests: testRecords,
+  };
+}
+
+// ─── Main Runner ─────────────────────────────────────────────────────────────
+
+function parseRunnerArgs() {
+  const args = process.argv.slice(2);
+  const config = {
+    testFile: null,
+    reportPath: null,
+    captureSnapshots: true,
+    retry: 0,
+    testTimeout: DEFAULT_TEST_TIMEOUT,
+    stopOnConsecutiveFailures: MAX_CONSECUTIVE_FAILURES,
+    autoRestart: true,
+    detailLevel: 'standard', // minimal | standard | full
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--report') {
+      config.reportPath = args[++i];
+    } else if (args[i] === '--no-snapshots') {
+      config.captureSnapshots = false;
+    } else if (args[i] === '--retry') {
+      config.retry = parseInt(args[++i]) || 0;
+    } else if (args[i] === '--test-timeout') {
+      config.testTimeout = parseInt(args[++i]) || DEFAULT_TEST_TIMEOUT;
+    } else if (args[i] === '--stop-after') {
+      config.stopOnConsecutiveFailures = parseInt(args[++i]) || MAX_CONSECUTIVE_FAILURES;
+    } else if (args[i] === '--no-auto-restart') {
+      config.autoRestart = false;
+    } else if (args[i] === '--detail') {
+      const level = args[++i];
+      if (level in DETAIL_LEVELS) config.detailLevel = level;
+      else { process.stderr.write(`Invalid detail level: ${level}. Use minimal|standard|full\n`); process.exit(1); }
+    } else if (!args[i].startsWith('--')) {
+      config.testFile = args[i];
+    }
+  }
+
+  return config;
+}
+
+function main() {
+  const config = parseRunnerArgs();
+
+  if (!config.testFile) {
+    process.stderr.write('Usage: node scripts/run-tests.mjs <test-file.json> [--report path] [--retry N] [--no-snapshots]\n');
+    process.exit(1);
+  }
+
+  // Read and validate test definitions
+  let testDefs;
+  try {
+    const raw = readFileSync(resolve(config.testFile), 'utf8');
+    testDefs = JSON.parse(raw);
+    // Support both array and object-with-tests format
+    if (!Array.isArray(testDefs)) {
+      if (testDefs.tests && Array.isArray(testDefs.tests)) {
+        if (testDefs.retry != null) config.retry = testDefs.retry;
+        if (testDefs.captureSnapshots != null) config.captureSnapshots = testDefs.captureSnapshots;
+        if (testDefs.testTimeout != null) config.testTimeout = testDefs.testTimeout;
+        testDefs = testDefs.tests;
+      } else {
+        testDefs = [testDefs];
+      }
+    }
+  } catch (err) {
+    process.stderr.write(`Failed to read test file: ${err.message}\n`);
+    process.exit(1);
+  }
+
+  // Schema validation
+  for (let i = 0; i < testDefs.length; i++) {
+    const validationError = validateTestDef(testDefs[i], i);
+    if (validationError) {
+      process.stderr.write(`[run-tests] Invalid test definition: ${validationError}\n`);
+      process.stdout.write(JSON.stringify({ _summary: true, total: 0, passed: 0, failed: 0, skipped: 0, elapsed: 0, error: validationError }) + '\n');
+      process.exit(1);
+    }
+  }
+
+  config._testFile = config.testFile;
+
+  // Pre-flight: check if TOKENICODE is running
+  const pingResult = cli('ping');
+  if (!pingResult.ok) {
+    process.stderr.write(`TOKENICODE is not running. Start with: pnpm tauri dev\n`);
+    process.stderr.write(`Ping result: ${JSON.stringify(pingResult)}\n`);
+    process.exit(1);
+  }
+
+  process.stderr.write(`[run-tests] Starting ${testDefs.length} test(s)...\n`);
+
+  const startTime = new Date();
+  const testRecords = [];
+  let consecutiveFailures = 0;
+  let abortedByBailout = false;
+
+  for (let i = 0; i < testDefs.length; i++) {
+    const testDef = testDefs[i];
+    process.stderr.write(`[run-tests] [${i + 1}/${testDefs.length}] ${testDef.name || `Test ${i + 1}`}...\n`);
+
+    const testRecord = executeTest(testDef, i, config);
+    testRecords.push(testRecord);
+
+    // Stdout summary line (one per test, for AI context)
+    const summary = {
+      test: testRecord.name,
+      status: testRecord.status,
+      elapsed: testRecord.elapsed,
+      attempts: testRecord.totalAttempts,
+    };
+    if (testRecord.status === 'fail') {
+      summary.error = testRecord.error;
+    }
+    process.stdout.write(JSON.stringify(summary) + '\n');
+
+    // Track consecutive failures for bailout
+    if (testRecord.status === 'fail') {
+      consecutiveFailures++;
+
+      if (config.autoRestart && consecutiveFailures >= config.stopOnConsecutiveFailures) {
+        process.stderr.write(`[run-tests] ${consecutiveFailures} consecutive failures — attempting restart...\n`);
+        let restartResult = cli('restart', [], {}, 30_000);
+        if (!restartResult.ok) {
+          process.stderr.write(`[run-tests] restart failed, escalating to relaunch...\n`);
+          restartResult = cli('relaunch', [], {}, 120_000);
+        }
+
+        if (restartResult.ok) {
+          process.stderr.write(`[run-tests] Recovery successful (${restartResult._elapsed || restartResult.elapsed}ms). Continuing tests...\n`);
+          consecutiveFailures = 0;
+        } else {
+          process.stderr.write(`[run-tests] Recovery failed: ${restartResult.error}. Aborting remaining tests.\n`);
+          abortedByBailout = true;
+
+          for (let j = i + 1; j < testDefs.length; j++) {
+            testRecords.push({
+              index: j,
+              name: testDefs[j].name || `Test ${j + 1}`,
+              status: 'skipped',
+              totalAttempts: 0,
+              elapsed: 0,
+              attempts: [],
+              steps: [],
+              error: 'Skipped: runner aborted after restart failure',
+              startTime: new Date().toISOString(),
+              endTime: new Date().toISOString(),
+            });
+          }
+          break;
+        }
+      }
+    } else {
+      consecutiveFailures = 0;
+    }
+  }
+
+  // Build and save report
+  const report = buildReport(testRecords, config, startTime);
+
+  if (abortedByBailout) {
+    report.meta.aborted = true;
+    report.meta.abortReason = 'Restart failed after consecutive test failures';
+  }
+
+  // Determine report path
+  const timestamp = startTime.toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const reportPath = config.reportPath || resolve(REPORT_DIR, `tokenicode-test-report-${timestamp}.json`);
+
+  let reportWritten = false;
+  let reportWriteError = null;
+  try {
+    mkdirSync(dirname(reportPath), { recursive: true });
+    writeFileSync(reportPath, JSON.stringify(report, null, 2), 'utf8');
+    reportWritten = true;
+  } catch (err) {
+    reportWriteError = err.message;
+    process.stderr.write(`[run-tests] Failed to write report: ${err.message}\n`);
+  }
+
+  // Final summary to stdout
+  process.stdout.write(JSON.stringify({
+    _summary: true,
+    total: report.meta.totalTests,
+    passed: report.meta.passed,
+    failed: report.meta.failed,
+    skipped: report.meta.skipped,
+    elapsed: report.meta.elapsed,
+    reportPath: reportWritten ? reportPath : null,
+    reportWritten,
+    reportWriteError,
+    aborted: !!report.meta.aborted,
+  }) + '\n');
+
+  process.stderr.write(`[run-tests] Done. ${report.meta.passed}/${report.meta.totalTests} passed. Report: ${reportWritten ? reportPath : 'FAILED TO WRITE'}\n`);
+
+  if (report.meta.failed > 0 || report.meta.aborted) {
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/tokenicode-cli.mjs
+++ b/scripts/tokenicode-cli.mjs
@@ -1,0 +1,715 @@
+#!/usr/bin/env node
+
+// tokenicode-cli.mjs — CLI tool for driving TOKENICODE GUI (debug builds)
+// Connects to the test harness Unix socket provided by tauri-plugin-mcp.
+// All output is JSON (one line per invocation) for AI consumption.
+// Zero external dependencies — Node.js built-in modules only.
+
+import { connect } from 'node:net';
+import { randomUUID } from 'node:crypto';
+import { execFileSync, execSync, spawn } from 'node:child_process';
+import { existsSync, rmSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const SOCKET_PATH = process.env.TOKENICODE_SOCKET || '/tmp/tokenicode-test.sock';
+const DEFAULT_TIMEOUT = 10_000;
+const SCREENSHOT_TIMEOUT = 15_000;
+const RESTART_TIMEOUT = 120_000;
+const POLL_INTERVAL = 500;
+
+// ─── Socket Client ───────────────────────────────────────────────────────────
+
+function createClient(socketPath) {
+  let socket = null;
+  let buffer = '';
+  let closed = false;
+  const pending = new Map(); // id → { resolve, reject, timer }
+
+  function rejectAll(reason) {
+    closed = true;
+    for (const [id, p] of pending) {
+      clearTimeout(p.timer);
+      p.reject(new Error(reason));
+    }
+    pending.clear();
+  }
+
+  function onData(chunk) {
+    buffer += chunk.toString();
+    let idx;
+    while ((idx = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, idx);
+      buffer = buffer.slice(idx + 1);
+      if (!line) continue;
+      try {
+        const msg = JSON.parse(line);
+        const p = pending.get(msg.id);
+        if (p) {
+          clearTimeout(p.timer);
+          pending.delete(msg.id);
+          p.resolve(msg);
+        }
+      } catch {
+        // Protocol error: log to stderr but keep processing
+        process.stderr.write(`[tokenicode-cli] malformed socket response: ${line.slice(0, 120)}\n`);
+      }
+    }
+  }
+
+  return {
+    connect() {
+      return new Promise((resolve, reject) => {
+        socket = connect({ path: socketPath }, () => {
+          // After successful connect, set up disconnect handlers
+          socket.on('close', () => rejectAll('Socket closed by TOKENICODE'));
+          socket.on('end', () => rejectAll('Socket connection ended'));
+          resolve();
+        });
+        socket.on('error', (err) => {
+          if (!closed) rejectAll(`Socket error: ${err.message}`);
+          reject(err);
+        });
+        socket.on('data', onData);
+      });
+    },
+
+    send(command, payload = {}, timeout = DEFAULT_TIMEOUT) {
+      if (closed) return Promise.reject(new Error('Socket already closed'));
+      return new Promise((resolve, reject) => {
+        const id = randomUUID();
+        const timer = setTimeout(() => {
+          pending.delete(id);
+          reject(new Error(`Command '${command}' timed out after ${timeout}ms`));
+        }, timeout);
+        pending.set(id, { resolve, reject, timer });
+        socket.write(JSON.stringify({ command, payload, id }) + '\n');
+      });
+    },
+
+    close() {
+      if (socket) {
+        closed = true;
+        for (const [, p] of pending) clearTimeout(p.timer);
+        pending.clear();
+        socket.destroy();
+      }
+    },
+  };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Run arbitrary JS in the TOKENICODE webview. Returns the raw result string. */
+async function execJs(client, code, timeout = DEFAULT_TIMEOUT) {
+  const resp = await client.send('execute_js', { code, window_label: 'main' }, timeout);
+  if (!resp.success) throw new Error(resp.error || 'execute_js failed');
+  if (resp.data?.type === 'error') throw new Error(resp.data.error || 'JS error in webview');
+  return resp.data?.result;
+}
+
+/** Call a window.__tokenicode_test method. Returns parsed JSON result. */
+async function callHelper(client, method, argsStr = '') {
+  const code = `JSON.stringify(window.__tokenicode_test.${method}(${argsStr}))`;
+  const raw = await execJs(client, code);
+  if (raw == null || raw === 'undefined' || raw === '') return null;
+  return JSON.parse(raw);
+}
+
+function parseArgs(argv) {
+  const flags = {};
+  const positional = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i].startsWith('--')) {
+      const key = argv[i].slice(2);
+      // Boolean flags (no value)
+      if (i + 1 >= argv.length || argv[i + 1].startsWith('--')) {
+        flags[key] = true;
+        continue;
+      }
+      flags[key] = argv[++i];
+    } else {
+      positional.push(argv[i]);
+    }
+  }
+  return { flags, positional };
+}
+
+function out(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+// ─── Command Handlers ────────────────────────────────────────────────────────
+// Each returns a plain object. Merged with { ok: true } on success.
+
+const commands = {
+
+  // ── Health ──
+
+  async ping(client) {
+    const resp = await client.send('ping', { value: 'test' });
+    if (!resp.success) throw new Error('Ping failed');
+    return { pong: true };
+  },
+
+  async status(client) {
+    return await callHelper(client, 'status');
+  },
+
+  // ── Chat: Input & Send ──
+
+  async type(client, { positional }) {
+    const text = positional.join(' ');
+    if (!text) throw new Error('Usage: type TEXT');
+    return await callHelper(client, 'type', JSON.stringify(text));
+  },
+
+  async send(client) {
+    return await callHelper(client, 'send');
+  },
+
+  async stop(client) {
+    return await callHelper(client, 'stop');
+  },
+
+  async 'delete-session'(client) {
+    return await callHelper(client, 'deleteCurrentSession');
+  },
+
+  // ── Chat: Read ──
+
+  async 'get-messages'(client, { flags }) {
+    const rawLast = flags.all ? undefined : parseInt(flags.last);
+    const last = rawLast != null ? Math.max(1, rawLast) : (flags.all ? undefined : 10);
+    const tabId = flags.tab;
+    const opts = {};
+    if (last != null) opts.last = last;
+    if (tabId) opts.tabId = tabId;
+    opts.summary = !flags.full;
+    return await callHelper(client, 'getMessages', JSON.stringify(opts));
+  },
+
+  async 'get-active-session'(client) {
+    const id = await callHelper(client, 'getActiveSessionId');
+    return { session: id };
+  },
+
+  async 'get-all-sessions'(client) {
+    const sessions = await callHelper(client, 'getAllSessions');
+    return { sessions, count: Array.isArray(sessions) ? sessions.length : 0 };
+  },
+
+  async 'get-current-model'(client) {
+    const model = await callHelper(client, 'getCurrentModel');
+    return { model };
+  },
+
+  async 'get-current-provider'(client) {
+    const provider = await callHelper(client, 'getCurrentProvider');
+    return { provider };
+  },
+
+  async 'is-streaming'(client, { flags }) {
+    const tabId = flags.tab;
+    const streaming = await callHelper(client, 'isStreaming', tabId ? JSON.stringify(tabId) : '');
+    return { streaming };
+  },
+
+  // ── Session Management ──
+
+  async 'switch-session'(client, { positional }) {
+    const id = positional[0];
+    if (!id) throw new Error('Usage: switch-session SESSION_ID');
+    // loadSession is async — execute_js doesn't await Promises.
+    // Use per-request ID to avoid race conditions between concurrent calls.
+    const reqId = randomUUID().slice(0, 8);
+    const startCode = `(function(){
+      if(!window.__tkn_loads) window.__tkn_loads = {};
+      window.__tkn_loads[${JSON.stringify(reqId)}] = {done:false, result:null};
+      window.__tokenicode_test.loadSession(${JSON.stringify(id)})
+        .then(function(r){ window.__tkn_loads[${JSON.stringify(reqId)}] = {done:true, result:r}; })
+        .catch(function(e){ window.__tkn_loads[${JSON.stringify(reqId)}] = {done:true, result:{error:e.message}}; });
+      return 'started';
+    })()`;
+    await execJs(client, startCode);
+
+    // Poll for completion (up to 30s)
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline) {
+      await sleep(300);
+      const doneRaw = await execJs(client, `JSON.stringify(window.__tkn_loads && window.__tkn_loads[${JSON.stringify(reqId)}])`);
+      if (doneRaw) {
+        const slot = JSON.parse(doneRaw);
+        if (slot && slot.done) {
+          // Clean up
+          await execJs(client, `delete window.__tkn_loads[${JSON.stringify(reqId)}]`).catch(() => {});
+          return slot.result || { switchedTo: id };
+        }
+      }
+    }
+    // Timeout — clean up and report failure
+    await execJs(client, `delete window.__tkn_loads[${JSON.stringify(reqId)}]`).catch(() => {});
+    throw new Error(`Session load timed out after 30s for ${id}`);
+  },
+
+  async 'new-session'(client, { flags }) {
+    const cwd = flags.cwd;
+    if (cwd) {
+      return await callHelper(client, 'newSession', JSON.stringify(cwd));
+    }
+    return await callHelper(client, 'newSession');
+  },
+
+  async 'check-editor'(client) {
+    try {
+      const code = `JSON.stringify({
+        hasEditor: !!document.querySelector('[data-testid=send-button]'),
+        hasChatPanel: !!document.querySelector('[data-testid=chat-messages]'),
+        session: window.__tokenicode_test.status().session
+      })`;
+      const raw = await execJs(client, code, 3000);
+      return raw ? JSON.parse(raw) : { hasEditor: false, hasChatPanel: false, session: null };
+    } catch {
+      return { hasEditor: false, hasChatPanel: false, session: null };
+    }
+  },
+
+  // ── Model & Provider ──
+
+  async 'switch-model'(client, { positional }) {
+    const id = positional[0];
+    if (!id) throw new Error('Usage: switch-model MODEL_ID');
+    return await callHelper(client, 'switchModel', JSON.stringify(id));
+  },
+
+  async 'switch-provider'(client, { positional }) {
+    const raw = positional[0];
+    if (raw === undefined) throw new Error('Usage: switch-provider PROVIDER_ID  (or "null" to reset)');
+    const id = raw === 'null' ? null : raw;
+    return await callHelper(client, 'switchProvider', JSON.stringify(id));
+  },
+
+  // ── Settings ──
+
+  async 'open-settings'(client) {
+    return await callHelper(client, 'openSettings');
+  },
+
+  async 'close-settings'(client) {
+    return await callHelper(client, 'closeSettings');
+  },
+
+  async 'switch-settings-tab'(client, { positional }) {
+    const id = positional[0];
+    if (!id) throw new Error('Usage: switch-settings-tab TAB_ID  (general|provider|cli|mcp)');
+    return await callHelper(client, 'switchSettingsTab', JSON.stringify(id));
+  },
+
+  // ── Permission ──
+
+  async 'allow-permission'(client) {
+    return await callHelper(client, 'allowPermission');
+  },
+
+  async 'deny-permission'(client) {
+    return await callHelper(client, 'denyPermission');
+  },
+
+  // ── Visual & Text ──
+
+  async screenshot(client) {
+    const resp = await client.send('take_screenshot', {
+      window_label: 'main',
+      save_to_disk: true,
+      thumbnail: false,
+    }, SCREENSHOT_TIMEOUT);
+    if (!resp.success) throw new Error(resp.error || 'Screenshot failed');
+    const path = resp.data?.filePath || resp.data?.file_path;
+    if (!path) throw new Error('Screenshot saved but no file path returned');
+    return { path };
+  },
+
+  async 'get-visible-text'(client, { flags }) {
+    // Returns the visible text on the page — what a human would see, no HTML/rendering noise.
+    // Optionally target a specific area via CSS selector.
+    const selector = flags.selector || 'body';
+    const code = `(function(){
+      var el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) return JSON.stringify({error: 'Element not found: ${selector}'});
+      var text = el.innerText;
+      return JSON.stringify({text: text, length: text.length});
+    })()`;
+    const raw = await execJs(client, code);
+    if (!raw) return { text: '', length: 0 };
+    return JSON.parse(raw);
+  },
+
+  async 'query-page'(client, { flags }) {
+    const mode = flags.mode || 'state';
+    const modeMap = {
+      map: 'get_page_map',
+      state: 'get_page_state',
+      info: 'get_app_info',
+    };
+    const command = modeMap[mode];
+    if (!command) throw new Error(`Invalid mode: ${mode}. Use map|state|info`);
+
+    const payload = { window_label: 'main' };
+    if (mode === 'map') {
+      payload.include_content = !flags['no-content'];
+      payload.interactive_only = !!flags['interactive-only'];
+      payload.include_metadata = true;
+    }
+    const resp = await client.send(command, payload);
+    if (!resp.success) throw new Error(resp.error || `${command} failed`);
+    return resp.data;
+  },
+
+  async 'get-dom'(client) {
+    const resp = await client.send('get_dom', { window_label: 'main' });
+    if (!resp.success) throw new Error(resp.error || 'get_dom failed');
+    return { html: resp.data };
+  },
+
+  // ── Waiting ──
+
+  async 'wait-for'(client, { positional, flags }) {
+    const timeout = parseInt(flags.timeout) || 10_000;
+    const payload = { window_label: 'main', timeout };
+
+    if (flags.text) {
+      payload.text = flags.text;
+    } else if (flags.selector) {
+      payload.selector = flags.selector;
+    } else if (positional.length > 0) {
+      payload.text = positional.join(' ');
+    } else {
+      throw new Error('Usage: wait-for --text TEXT | --selector SELECTOR | TEXT');
+    }
+
+    const resp = await client.send('wait_for', payload, timeout + 2000);
+    if (!resp.success) throw new Error(resp.error || 'wait_for failed');
+    return { found: true, ...(resp.data || {}) };
+  },
+
+  async 'wait-until-done'(client, { flags }) {
+    const timeout = parseInt(flags.timeout) || 60_000;
+    const start = Date.now();
+
+    // Brief delay to let CLI process start
+    await sleep(300);
+
+    while (Date.now() - start < timeout) {
+      const status = await callHelper(client, 'status');
+
+      if (status.pendingPermission) {
+        return { status: 'permission_pending', elapsed: Date.now() - start, ...status };
+      }
+      if (!status.active) {
+        return { status: 'completed', elapsed: Date.now() - start, ...status };
+      }
+
+      await sleep(POLL_INTERVAL);
+    }
+
+    const finalStatus = await callHelper(client, 'status');
+    return {
+      status: 'timeout',
+      error: `Timed out after ${timeout}ms (phase: ${finalStatus.phase}, msgs: ${finalStatus.messageCount})`,
+      elapsed: Date.now() - start,
+      ...finalStatus,
+    };
+  },
+
+  async 'wait-for-phase'(client, { positional, flags }) {
+    const target = positional[0];
+    if (!target) throw new Error('Usage: wait-for-phase PHASE [--timeout MS]  (phases: thinking|writing|tool|awaiting|completed)');
+    const timeout = parseInt(flags.timeout) || 30_000;
+    const start = Date.now();
+    await sleep(300);
+    while (Date.now() - start < timeout) {
+      const status = await callHelper(client, 'status');
+      if (status.phase === target) {
+        return { phase: target, elapsed: Date.now() - start, ...status };
+      }
+      if (!status.active && status.phase !== target) {
+        return { error: `Session ended (phase: ${status.phase}) before reaching '${target}'`, elapsed: Date.now() - start, ...status };
+      }
+      await sleep(POLL_INTERVAL);
+    }
+    const finalStatus = await callHelper(client, 'status');
+    return { error: `Timed out waiting for phase '${target}' after ${timeout}ms`, elapsed: Date.now() - start, ...finalStatus };
+  },
+
+  async delay(_client, { positional }) {
+    const ms = parseInt(positional[0]) || 1000;
+    if (ms > 300_000) throw new Error('delay max 300s');
+    await sleep(ms);
+    return { delayed: ms };
+  },
+
+  // ── Raw JS ──
+
+  async exec(client, { positional, flags }) {
+    const code = positional.join(' ');
+    if (!code) throw new Error('Usage: exec JS_CODE');
+    const timeout = parseInt(flags.timeout) || DEFAULT_TIMEOUT;
+    // Auto-wrap in stringify to handle object return values that otherwise serialize to undefined
+    const wrapped = `(function(){try{var __r=(${code});return typeof __r==='object'&&__r!==null?JSON.stringify(__r):String(__r)}catch(e){return JSON.stringify({__error:e.message})}})()`;
+    const raw = await execJs(client, wrapped, timeout);
+    try {
+      return { result: JSON.parse(raw) };
+    } catch {
+      return { result: raw };
+    }
+  },
+
+  // ── Restart ──
+
+  async restart(client, { flags }) {
+    // Soft restart: reload webview in the same window (no new window).
+    // Resets frontend state while keeping the Tauri process alive.
+    const timeout = parseInt(flags.timeout) || 30_000;
+    const start = Date.now();
+
+    // Trigger reload
+    await execJs(client, 'location.reload()').catch(() => {});
+    await sleep(2000);
+
+    // Poll until webview is ready (test harness re-initialized after reload)
+    while (Date.now() - start < timeout) {
+      try {
+        const r = await execJs(client, '"ready"', 3000);
+        if (r === 'ready') {
+          return { restarted: true, mode: 'reload', elapsed: Date.now() - start };
+        }
+      } catch { /* webview not ready yet */ }
+      await sleep(1000);
+    }
+    throw new Error(`Webview reload timed out after ${Date.now() - start}ms`);
+  },
+
+  async relaunch(_client, { flags }) {
+    // Hard restart: kill Tauri process tree + Vite, relaunch `pnpm tauri dev` (opens new window).
+    // This is a standalone command — it manages its own socket connections.
+    const timeout = parseInt(flags.timeout) || RESTART_TIMEOUT;
+    const start = Date.now();
+
+    // Step 1: Find the process that owns the socket (uses SOCKET_PATH, not hardcoded name)
+    let pid = null;
+    try {
+      // lsof -t returns only PIDs. Use -- to prevent SOCKET_PATH being treated as a flag.
+      const lsofOut = execFileSync('lsof', ['-t', '-U', '--', SOCKET_PATH], {
+        encoding: 'utf8',
+        timeout: 5000,
+      });
+      const pids = lsofOut.trim().split('\n').map(Number).filter(Boolean);
+      // Take the first PID (the server process)
+      if (pids.length > 0) pid = pids[0];
+    } catch { /* socket not found or lsof failed — app may already be dead */ }
+
+    // Step 2: Kill the process group
+    if (pid) {
+      // Resolve the actual process group ID (PGID may differ from PID)
+      let pgid = pid;
+      try {
+        const pgidOut = execFileSync('ps', ['-o', 'pgid=', '-p', String(pid)], {
+          encoding: 'utf8',
+          timeout: 3000,
+        });
+        const parsed = parseInt(pgidOut.trim());
+        if (parsed > 0) pgid = parsed;
+      } catch { /* fallback to using pid as pgid */ }
+
+      try {
+        process.kill(-pgid, 'SIGTERM');
+      } catch {
+        try { process.kill(pid, 'SIGKILL'); } catch { /* already dead */ }
+      }
+      // Wait for process to die (up to 10s), escalate to SIGKILL if needed
+      const killDeadline = Date.now() + 10_000;
+      let alive = true;
+      while (Date.now() < killDeadline) {
+        try { process.kill(pid, 0); } catch { alive = false; break; }
+        await sleep(300);
+      }
+      if (alive) {
+        // Escalate to SIGKILL
+        try { process.kill(-pgid, 'SIGKILL'); } catch {}
+        try { process.kill(pid, 'SIGKILL'); } catch {}
+        await sleep(500);
+      }
+    }
+
+    // Step 2.5a: Kill any orphaned target/debug/tokenicode processes that survived PGID kill.
+    // After hours of unattended testing with repeated relaunches, child processes can accumulate
+    // as zombies (~1.5 GB after 76 processes). pkill returns non-zero if no matches, so wrap in try/catch.
+    try {
+      execSync('pkill -9 -f "target/debug/tokenicode"', { timeout: 5000, stdio: 'ignore' });
+      await sleep(500);
+    } catch { /* no matching processes — expected on clean shutdown */ }
+
+    // Step 2.5b: Kill Vite dev server on port 1420 (may survive PGID kill)
+    try {
+      const viteOut = execFileSync('lsof', ['-t', '-i', ':1420'], { encoding: 'utf8', timeout: 3000 });
+      for (const vpid of viteOut.trim().split('\n').map(Number).filter(Boolean)) {
+        try { process.kill(vpid, 'SIGTERM'); } catch { /* already dead */ }
+      }
+      await sleep(1000);
+    } catch { /* no Vite server running */ }
+
+    // Step 3: Clean up stale socket (always, regardless of whether pid was found)
+    if (existsSync(SOCKET_PATH)) {
+      try { rmSync(SOCKET_PATH, { force: true }); } catch { /* best effort */ }
+    }
+
+    // Step 4: Relaunch pnpm tauri dev
+    const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+    const env = { ...process.env, PATH: `${process.env.HOME}/.cargo/bin:${process.env.PATH}` };
+
+    // Wait for spawn confirmation — detect both ENOENT (error event) and early crash (exit event)
+    const child = await new Promise((resolveSpawn, rejectSpawn) => {
+      const proc = spawn('pnpm', ['tauri', 'dev'], {
+        cwd: projectRoot,
+        detached: true,
+        stdio: 'ignore',
+        env,
+      });
+      let settled = false;
+      const settle = () => {
+        if (settled) return;
+        settled = true;
+        proc.removeAllListeners('error');
+        proc.removeAllListeners('exit');
+        resolveSpawn(proc);
+      };
+      const earlyTimer = setTimeout(settle, 2000);
+      proc.on('error', (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(earlyTimer);
+        rejectSpawn(new Error(`Failed to start pnpm tauri dev: ${err.message}`));
+      });
+      proc.on('exit', (code, signal) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(earlyTimer);
+        rejectSpawn(new Error(`pnpm tauri dev exited immediately: code=${code} signal=${signal}`));
+      });
+    });
+    child.unref();
+
+    // Step 5: Poll ping until the app is ready
+    const pollDeadline = start + timeout;
+    while (Date.now() < pollDeadline) {
+      await sleep(2000);
+      try {
+        const testClient = createClient(SOCKET_PATH);
+        await testClient.connect();
+        const resp = await testClient.send('ping', { value: 'restart' }, 5000);
+        testClient.close();
+        if (resp.success) {
+          return { restarted: true, elapsed: Date.now() - start, pid: child.pid };
+        }
+      } catch {
+        // Not ready yet — keep polling
+      }
+    }
+
+    throw new Error(`Restart timed out after ${Date.now() - start}ms — app did not become ready`);
+  },
+
+  // ── Help (JSON) ──
+
+  async help() {
+    return {
+      usage: 'node scripts/tokenicode-cli.mjs <command> [args] [--flags]',
+      commands: {
+        health: ['ping', 'status', 'restart [--timeout MS]', 'relaunch [--timeout MS]'],
+        chat: ['type TEXT', 'send', 'stop', 'delete-session', 'get-messages [--last N] [--all] [--tab ID] [--full]', 'check-editor'],
+        session: ['get-active-session', 'get-all-sessions', 'switch-session ID', 'new-session [--cwd PATH]'],
+        model: ['get-current-model', 'get-current-provider', 'switch-model ID', 'switch-provider ID'],
+        settings: ['open-settings', 'close-settings', 'switch-settings-tab ID'],
+        permission: ['allow-permission', 'deny-permission'],
+        visual: ['screenshot', 'get-visible-text [--selector CSS]', 'query-page [--mode map|state|info]', 'get-dom'],
+        waiting: ['wait-for --text TEXT|--selector SEL [--timeout MS]', 'wait-until-done [--timeout MS]', 'wait-for-phase PHASE [--timeout MS]', 'delay MS'],
+        raw: ['exec JS_CODE [--timeout MS]'],
+      },
+      env: { TOKENICODE_SOCKET: `Override socket path (default: ${SOCKET_PATH})` },
+    };
+  },
+};
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const argv = process.argv.slice(2);
+
+  // Commands that don't need a pre-connected socket
+  const noSocketCommands = new Set(['help', 'relaunch', 'delay']);
+
+  if (argv.length === 0 || argv[0] === 'help' || argv[0] === '--help' || argv[0] === '-h') {
+    const result = await commands.help();
+    out({ ok: true, ...result });
+    return;
+  }
+
+  const cmd = argv[0];
+  const handler = commands[cmd];
+  if (!handler) {
+    out({ ok: false, error: `Unknown command: '${cmd}'. Run with 'help' for available commands.` });
+    process.exit(1);
+  }
+
+  const parsed = parseArgs(argv.slice(1));
+
+  // relaunch manages its own socket connections
+  if (noSocketCommands.has(cmd)) {
+    try {
+      const result = await handler(null, parsed);
+      out({ ok: true, ...result });
+    } catch (err) {
+      out({ ok: false, error: err.message });
+      process.exit(1);
+    }
+    return;
+  }
+
+  let client;
+  try {
+    client = createClient(SOCKET_PATH);
+    await client.connect();
+  } catch (err) {
+    const msg =
+      err.code === 'ENOENT'
+        ? `TOKENICODE not running (socket not found at ${SOCKET_PATH}). Start with: pnpm tauri dev`
+        : err.code === 'ECONNREFUSED'
+          ? `Socket exists but connection refused. Is TOKENICODE debug build running?`
+          : `Cannot connect to TOKENICODE: ${err.message}`;
+    out({ ok: false, error: msg });
+    process.exit(1);
+  }
+
+  try {
+    const result = await handler(client, parsed);
+    // If handler returned an object with 'error' key (from test helper), preserve full context
+    if (result && result.error && !result.ok) {
+      out({ ok: false, ...result });
+      process.exit(1);
+    }
+    out({ ok: true, ...result });
+  } catch (err) {
+    out({ ok: false, error: err.message });
+    process.exit(1);
+  } finally {
+    client.close();
+  }
+}
+
+main();

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -246,6 +246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,7 +514,7 @@ dependencies = [
  "block",
  "cocoa-foundation",
  "core-foundation 0.10.1",
- "core-graphics",
+ "core-graphics 0.24.0",
  "foreign-types 0.5.0",
  "libc",
  "objc",
@@ -523,9 +529,15 @@ dependencies = [
  "bitflags 2.11.0",
  "block",
  "core-foundation 0.10.1",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "objc",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
@@ -596,14 +608,51 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -661,10 +710,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -746,6 +820,17 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -873,6 +958,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,6 +998,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embed-resource"
@@ -1010,6 +1107,21 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
 ]
 
 [[package]]
@@ -1398,6 +1510,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,6 +1684,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1897,6 +2030,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "exr",
+ "gif",
+ "jpeg-decoder",
+ "num-traits",
+ "png",
+ "qoi",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,6 +2115,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "interprocess"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+dependencies = [
+ "doctest-file",
+ "futures-core",
+ "libc",
+ "recvmsg",
+ "tokio",
+ "widestring",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2063,6 +2229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2325,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,6 +2359,16 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -2459,6 +2650,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -3080,7 +3280,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3221,6 +3421,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3330,6 +3548,32 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -4201,6 +4445,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows 0.52.0",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4243,7 +4502,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block2",
  "core-foundation 0.10.1",
- "core-graphics",
+ "core-graphics 0.24.0",
  "crossbeam-channel",
  "dispatch",
  "dlopen2",
@@ -4471,6 +4730,31 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-mcp"
+version = "0.1.0"
+source = "git+https://github.com/P3GLEG/tauri-plugin-mcp#ac709a71d30ac2f167dd79c4f803500a236262f6"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "core-foundation 0.9.4",
+ "core-graphics 0.22.3",
+ "foreign-types-shared 0.1.1",
+ "image",
+ "interprocess",
+ "log",
+ "serde",
+ "serde_json",
+ "subtle",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+ "win-screenshot",
+ "xcap",
 ]
 
 [[package]]
@@ -4725,6 +5009,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4767,7 +5062,7 @@ dependencies = [
 
 [[package]]
 name = "tokenicode"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "base64 0.22.1",
  "cocoa",
@@ -4787,6 +5082,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-mcp",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-shell",
@@ -5538,6 +5834,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "win-screenshot"
+version = "4.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46fb2d7cb00430b7c433b05cc37a0f2f03a5305a975b1886a6ce5e1d8977d4b"
+dependencies = [
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5585,6 +5902,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
@@ -5599,11 +5926,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -5613,6 +5952,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5661,7 +6018,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -5728,6 +6096,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5886,6 +6264,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6234,6 +6621,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "xcap"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6776c1b371ea7c73bc98a40ae5c6a69c648669ff2e6d8a03fc8b80ddc58a0498"
+dependencies = [
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "dbus",
+ "image",
+ "log",
+ "percent-encoding",
+ "sysinfo",
+ "thiserror 1.0.69",
+ "windows 0.52.0",
+ "xcb",
+]
+
+[[package]]
+name = "xcb"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "quick-xml 0.30.0",
+]
+
+[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6506,6 +6922,15 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ flate2 = "1"
 tar = "0.4"
 zip = "2"
 sha2 = "0.10"
+tauri-plugin-mcp = { git = "https://github.com/P3GLEG/tauri-plugin-mcp" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6724,6 +6724,20 @@ pub fn run() {
             app.handle()
                 .plugin(tauri_plugin_updater::Builder::new().build())?;
 
+            // Register test harness socket server (debug builds only).
+            // Provides a Unix socket that tokenicode-cli.mjs connects to for
+            // automated GUI testing. Release builds never include this.
+            #[cfg(debug_assertions)]
+            {
+                let mcp_config = tauri_plugin_mcp::PluginConfig::new("TOKENICODE".to_string())
+                    .start_socket_server(true)
+                    .socket_path(std::path::PathBuf::from("/tmp/tokenicode-test.sock"));
+                app.handle().plugin(
+                    tauri_plugin_mcp::init_with_config(mcp_config)
+                )?;
+                eprintln!("[TOKENICODE] Test harness registered on /tmp/tokenicode-test.sock");
+            }
+
             #[cfg(not(desktop))]
             let _ = app;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { useSessionStore } from './stores/sessionStore';
 import { APP_NAME, IS_ALPHA } from './lib/edition';
 import { useAgentStore } from './stores/agentStore';
 import { bridge, onFileChange } from './lib/tauri-bridge';
+import { parseSessionMessages } from './lib/session-loader';
 import { inspectSessionForRecovery } from './lib/session-recovery';
 import { useAutoUpdateCheck } from './hooks/useAutoUpdateCheck';
 import { useT } from './lib/i18n';
@@ -117,6 +118,215 @@ function App() {
     checkCliUpdate();
     const interval = setInterval(checkCliUpdate, 30 * 60 * 1000);
     return () => clearInterval(interval);
+  }, []);
+
+  // ── Test harness helpers (dev builds only) ──────────────────────
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+
+    // Initialize tauri-plugin-mcp frontend listeners (execute-js, get-page-map, etc.)
+    import('tauri-plugin-mcp').then(({ setupPluginListeners }) => {
+      setupPluginListeners();
+    }).catch((e) => console.warn('[TOKENICODE] Failed to init MCP plugin listeners:', e));
+
+    (window as any).__tokenicode_test = {
+      getMessages(optsOrTabId?: string | { tabId?: string; last?: number; summary?: boolean }) {
+        const opts = typeof optsOrTabId === 'string' ? { tabId: optsOrTabId } : (optsOrTabId || {});
+        const id = opts.tabId || useSessionStore.getState().selectedSessionId;
+        if (!id) return { messages: [], total: 0 };
+        const tab = useChatStore.getState().tabs.get(id);
+        const all = tab?.messages || [];
+        const total = all.length;
+        const messages = opts.last != null ? all.slice(-opts.last) : all;
+        if (opts.summary) {
+          return {
+            messages: messages.map((m: any) => ({
+              id: m.id, role: m.role, type: m.type, toolName: m.toolName || undefined,
+              content: m.type === 'tool_result' ? `[tool_result: ${(m.content || '').slice(0, 80)}...]`
+                : m.type === 'thinking' ? '[thinking]' : (m.content || '').slice(0, 150),
+              subAgentDepth: m.subAgentDepth, timestamp: m.timestamp,
+            })),
+            total,
+          };
+        }
+        return { messages, total };
+      },
+      getLastMessage(tabId?: string) {
+        const { messages } = (window as any).__tokenicode_test.getMessages({ tabId, last: 1 });
+        return messages[0] || null;
+      },
+      getActiveSessionId() { return useSessionStore.getState().selectedSessionId; },
+      getAllSessions() { return useSessionStore.getState().sessions; },
+      getCurrentModel() { return useSettingsStore.getState().selectedModel; },
+      getCurrentProvider() { return useProviderStore.getState().activeProviderId; },
+      isStreaming(tabId?: string) {
+        const id = tabId || useSessionStore.getState().selectedSessionId;
+        if (!id) return false;
+        const tab = useChatStore.getState().tabs.get(id);
+        if (!tab) return false;
+        return !!(tab.partialText || tab.activityStatus?.phase === 'thinking');
+      },
+      isSettingsOpen() { return useSettingsStore.getState().settingsOpen; },
+      status() {
+        const sessionId = useSessionStore.getState().selectedSessionId;
+        const tab = sessionId ? useChatStore.getState().tabs.get(sessionId) : null;
+        const phase = tab?.activityStatus?.phase;
+        const activePhases = new Set(['thinking', 'writing', 'tool', 'awaiting']);
+        const active = !!(tab?.partialText || (phase && activePhases.has(phase)));
+        return {
+          session: sessionId, sessionCount: useSessionStore.getState().sessions.length,
+          model: useSettingsStore.getState().selectedModel,
+          provider: useProviderStore.getState().activeProviderId,
+          active, phase: phase || null,
+          pendingPermission: !!(window as any).__tokenicode_respond_permission,
+          settingsOpen: useSettingsStore.getState().settingsOpen,
+          messageCount: tab?.messages?.length || 0,
+        };
+      },
+      type(text: string) {
+        const editor = (window as any).__tokenicode_editor;
+        if (!editor) return { error: 'Editor not available (no active session)' };
+        editor.commands.clearContent();
+        editor.commands.insertContent(text);
+        return { typed: text };
+      },
+      send() {
+        const fn = (window as any).__tokenicode_send;
+        if (!fn) return { error: 'Send handler not available' };
+        fn();
+        return { sent: true };
+      },
+      async loadSession(sessionId: string) {
+        const sessions = useSessionStore.getState().sessions;
+        const session = sessions.find((s: any) => s.id === sessionId);
+        if (!session) return { error: `Session ${sessionId} not found` };
+        const currentId = useSessionStore.getState().selectedSessionId;
+        if (currentId) {
+          useChatStore.getState().saveToCache(currentId);
+          useAgentStore.getState().saveToCache(currentId);
+        }
+        useFileStore.getState().closePreview();
+        useSessionStore.getState().setSelectedSession(sessionId);
+        const restored = useChatStore.getState().restoreFromCache(sessionId);
+        if (restored) {
+          useAgentStore.getState().restoreFromCache(sessionId);
+          if (session.project) {
+            const dir = session.project.startsWith('/') ? session.project : session.projectDir || session.project;
+            useSettingsStore.getState().setWorkingDirectory(dir);
+          }
+          return { switchedTo: sessionId, restored: true, messageCount: useChatStore.getState().tabs.get(sessionId)?.messages?.length || 0 };
+        }
+        if (!session.path) {
+          useChatStore.getState().ensureTab(sessionId);
+          useChatStore.getState().resetTab(sessionId);
+          useAgentStore.getState().clearAgents();
+          return { switchedTo: sessionId, restored: false, messageCount: 0, note: 'draft session (no JSONL)' };
+        }
+        useChatStore.getState().ensureTab(sessionId);
+        const dir = session.project?.startsWith('/') ? session.project : session.projectDir || session.project || '';
+        useSettingsStore.getState().setWorkingDirectory(dir);
+        const { clearMessages, addMessage, setSessionStatus, setSessionMeta } = useChatStore.getState();
+        clearMessages(sessionId);
+        useAgentStore.getState().clearAgents();
+        setSessionStatus(sessionId, 'running');
+        setSessionMeta(sessionId, { sessionId, stdinId: undefined });
+        try {
+          const rawMessages = await bridge.loadSession(session.path);
+          if (useSessionStore.getState().selectedSessionId !== sessionId) {
+            return { switchedTo: sessionId, aborted: true, note: 'User switched away during load' };
+          }
+          const { messages, agents } = parseSessionMessages(rawMessages);
+          for (const agent of agents) useAgentStore.getState().upsertAgent(agent);
+          for (const msg of messages) {
+            if ((msg as any).toolResultContent) {
+              const { toolResultContent, ...baseMsg } = msg as any;
+              addMessage(sessionId, baseMsg);
+              useChatStore.getState().updateMessage(sessionId, msg.id, { toolResultContent });
+            } else { addMessage(sessionId, msg); }
+          }
+          setSessionStatus(sessionId, 'completed');
+          return { switchedTo: sessionId, restored: false, messageCount: messages.length };
+        } catch (err: any) {
+          if (useSessionStore.getState().selectedSessionId !== sessionId) {
+            return { switchedTo: sessionId, aborted: true, note: 'User switched away during load' };
+          }
+          useChatStore.getState().setSessionStatus(sessionId, 'error');
+          return { switchedTo: sessionId, error: `Failed to load: ${err.message}` };
+        }
+      },
+      switchSession(sessionId: string) {
+        const sessionState = useSessionStore.getState();
+        const currentId = sessionState.selectedSessionId;
+        if (currentId) {
+          useChatStore.getState().saveToCache(currentId);
+          useAgentStore.getState().saveToCache(currentId);
+        }
+        sessionState.setSelectedSession(sessionId);
+        const restored = useChatStore.getState().restoreFromCache(sessionId);
+        if (restored) useAgentStore.getState().restoreFromCache(sessionId);
+        useFileStore.getState().closePreview();
+        return { switchedTo: sessionId, restored };
+      },
+      newSession(cwd?: string) {
+        const currentTabId = useSessionStore.getState().selectedSessionId;
+        if (currentTabId) {
+          useChatStore.getState().saveToCache(currentTabId);
+          useAgentStore.getState().saveToCache(currentTabId);
+          if (currentTabId.startsWith('desk_')) {
+            const tabState = useChatStore.getState().tabs.get(currentTabId);
+            if (!tabState || tabState.messages.length === 0) {
+              useSessionStore.getState().removeDraft(currentTabId);
+              useChatStore.getState().removeTab(currentTabId);
+            }
+          }
+        }
+        if (!cwd) {
+          useSessionStore.getState().setSelectedSession(null);
+          useSettingsStore.getState().setWorkingDirectory('');
+          return { action: 'newSession' };
+        }
+        const newId = `desk_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+        useSessionStore.getState().setSelectedSession(newId);
+        useSettingsStore.getState().setWorkingDirectory(cwd);
+        useChatStore.getState().restoreFromCache(newId);
+        return { action: 'newSession', session: newId };
+      },
+      switchModel(modelId: string) { useSettingsStore.getState().setSelectedModel(modelId); return { model: modelId }; },
+      switchProvider(providerId: string | null) { useProviderStore.getState().setActive(providerId); return { provider: providerId }; },
+      openSettings() { useSettingsStore.setState({ settingsOpen: true }); return { settingsOpen: true }; },
+      closeSettings() { useSettingsStore.setState({ settingsOpen: false }); return { settingsOpen: false }; },
+      switchSettingsTab(tabId: string) {
+        const btn = document.querySelector(`[data-testid="settings-tab-${tabId}"]`);
+        if (btn) { (btn as HTMLElement).click(); return { tab: tabId }; }
+        return { error: `Tab ${tabId} not found` };
+      },
+      allowPermission() {
+        const fn = (window as any).__tokenicode_respond_permission;
+        if (!fn) return { error: 'No pending permission request' };
+        fn(true); return { allowed: true };
+      },
+      denyPermission() {
+        const fn = (window as any).__tokenicode_respond_permission;
+        if (!fn) return { error: 'No pending permission request' };
+        fn(false); return { denied: true };
+      },
+      stop() {
+        const btn = document.querySelector('[data-testid="stop-button"]') as HTMLElement;
+        if (!btn) return { stopped: false, reason: 'no running session' };
+        btn.click(); return { stopped: true };
+      },
+      deleteCurrentSession() {
+        const sessionId = useSessionStore.getState().selectedSessionId;
+        if (!sessionId) return { deleted: false, reason: 'no active session' };
+        const stdinId = useChatStore.getState().tabs.get(sessionId)?.sessionMeta?.stdinId;
+        if (stdinId) bridge.killSession(stdinId).catch(() => {});
+        useChatStore.getState().removeTab(sessionId);
+        useAgentStore.getState().clearAgents();
+        if (sessionId.startsWith('desk_')) useSessionStore.getState().removeDraft(sessionId);
+        useSessionStore.getState().setSelectedSession(null);
+        return { deleted: true, session: sessionId };
+      },
+    };
   }, []);
 
   // ── Global stream watchdog + auto-recovery ──────────────────────

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -542,7 +542,8 @@ export function ChatPanel() {
       <div className="flex flex-1 min-h-0 relative">
       {/* Main chat area */}
       <div className="flex flex-col flex-1 min-w-0">
-      <div ref={scrollRef} onScroll={handleScroll} className="flex-1 overflow-y-auto px-5 py-6 selectable">
+      <div ref={scrollRef} onScroll={handleScroll} className="flex-1 overflow-y-auto px-5 py-6 selectable"
+        {...(import.meta.env.DEV && { 'data-testid': 'chat-messages' })}>
         {!workingDirectory && messages.length === 0 && !isStreaming ? (
           <WelcomeScreen />
         ) : messages.length === 0 && !isStreaming ? (

--- a/src/components/chat/InputBar.tsx
+++ b/src/components/chat/InputBar.tsx
@@ -1137,6 +1137,18 @@ export function InputBar() {
   // Keep ref in sync so executeImmediateCommand can call latest handleSubmit
   handleSubmitRef.current = handleSubmit;
 
+  // Expose send handler for test harness (dev only)
+  useEffect(() => {
+    if (import.meta.env.DEV) {
+      (window as any).__tokenicode_send = handleSubmit;
+    }
+    return () => {
+      if (import.meta.env.DEV) {
+        delete (window as any).__tokenicode_send;
+      }
+    };
+  }, [handleSubmit]);
+
   // handleStreamMessage and handleBackgroundStreamMessage are provided by
   // useStreamProcessor hook (see src/hooks/useStreamProcessor.ts).
 
@@ -1506,6 +1518,7 @@ export function InputBar() {
                   }, 3000);
                 }
               }}
+              {...(import.meta.env.DEV && { 'data-testid': 'stop-button' })}
               className="flex-shrink-0 self-end w-8 h-8 rounded-[10px]
                 bg-red-500/15 text-red-500
                 flex items-center justify-center
@@ -1521,6 +1534,7 @@ export function InputBar() {
           <button
             onClick={handleSubmit}
             disabled={isAwaiting || (!input.trim() && !activePrefix)}
+            {...(import.meta.env.DEV && { 'data-testid': 'send-button' })}
             className={`flex-shrink-0 self-end w-8 h-8 rounded-[10px]
               flex items-center justify-center transition-smooth
               disabled:opacity-30 disabled:cursor-not-allowed

--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -87,6 +87,7 @@ export function ModelSelector({ disabled = false }: { disabled?: boolean }) {
       <button
         onClick={() => !disabled && setOpen(!open)}
         disabled={disabled}
+        {...(import.meta.env.DEV && { 'data-testid': 'model-selector' })}
         className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg
           text-xs text-text-muted hover:text-text-primary
           hover:bg-bg-secondary transition-smooth
@@ -114,6 +115,7 @@ export function ModelSelector({ disabled = false }: { disabled?: boolean }) {
                 <div className="border-t border-border-subtle my-1" />
               )}
               <button
+                {...(import.meta.env.DEV && { 'data-testid': `model-option-${option.id}` })}
                 onClick={() => {
                   if (option.id !== selectedModel) {
                     const oldShort = current.short;

--- a/src/components/chat/PermissionCard.tsx
+++ b/src/components/chat/PermissionCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { type ChatMessage, useChatStore, getActiveTabState } from '../../stores/chatStore';
 import { useSessionStore } from '../../stores/sessionStore';
 import { bridge } from '../../lib/tauri-bridge';
@@ -89,8 +89,21 @@ export function PermissionCard({ message }: Props) {
   const isFailed = interactionState === 'failed';
   const isPending = interactionState === 'pending';
 
+  // Expose permission respond handler for test harness (dev only)
+  useEffect(() => {
+    if (import.meta.env.DEV && isPending) {
+      (window as any).__tokenicode_respond_permission = handleRespond;
+    }
+    return () => {
+      if (import.meta.env.DEV) {
+        delete (window as any).__tokenicode_respond_permission;
+      }
+    };
+  }, [handleRespond, isPending]);
+
   return (
-    <div className={`ml-11 animate-scale-in ${isResolved ? 'opacity-60' : ''}`}>
+    <div className={`ml-11 animate-scale-in ${isResolved ? 'opacity-60' : ''}`}
+      {...(import.meta.env.DEV && { 'data-testid': 'permission-card' })}>
       <div className={`rounded-xl border overflow-hidden transition-all duration-200
         ${isResolved
           ? 'border-border-subtle bg-bg-secondary/30'
@@ -178,6 +191,7 @@ export function PermissionCard({ message }: Props) {
               <>
                 <button
                   onClick={() => handleRespond(true)}
+                  {...(import.meta.env.DEV && { 'data-testid': 'permission-allow-button' })}
                   className="px-4 py-2 rounded-lg text-xs font-semibold
                     border-2 border-success/40 text-success bg-success/5
                     hover:bg-success/15 transition-smooth cursor-pointer
@@ -191,6 +205,7 @@ export function PermissionCard({ message }: Props) {
                 </button>
                 <button
                   onClick={() => handleRespond(false)}
+                  {...(import.meta.env.DEV && { 'data-testid': 'permission-deny-button' })}
                   className="px-3 py-2 rounded-lg text-xs font-medium
                     text-text-muted border border-border-subtle
                     hover:bg-bg-secondary hover:text-text-primary

--- a/src/components/chat/TiptapEditor.tsx
+++ b/src/components/chat/TiptapEditor.tsx
@@ -207,6 +207,18 @@ export const TiptapEditor = forwardRef<TiptapEditorHandle, TiptapEditorProps>(
       });
     }, [editor, placeholder]);
 
+    // Expose editor for test harness (dev only)
+    useEffect(() => {
+      if (import.meta.env.DEV && editor) {
+        (window as any).__tokenicode_editor = editor;
+      }
+      return () => {
+        if (import.meta.env.DEV) {
+          delete (window as any).__tokenicode_editor;
+        }
+      };
+    }, [editor]);
+
     useImperativeHandle(ref, () => ({
       getText() {
         return editorToPlainText(editor);
@@ -256,6 +268,7 @@ export const TiptapEditor = forwardRef<TiptapEditorHandle, TiptapEditorProps>(
         ref={wrapperRef}
         className={className}
         data-chat-input={props['data-chat-input'] ? '' : undefined}
+        {...(import.meta.env.DEV && { 'data-testid': 'chat-input-editor' })}
       >
         <EditorContent editor={editor} />
       </div>

--- a/src/components/conversations/SessionItem.tsx
+++ b/src/components/conversations/SessionItem.tsx
@@ -138,6 +138,7 @@ export function SessionItem({
 
   return (
     <button
+      {...(import.meta.env.DEV && { 'data-testid': `session-item-${session.id}` })}
       onClick={(e) => {
         if (multiSelect && onToggleCheck) {
           onToggleCheck(session.id, e.shiftKey);

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -90,6 +90,7 @@ export function Sidebar() {
         // Clear working directory so ChatPanel shows WelcomeScreen
         useSettingsStore.getState().setWorkingDirectory('');
       }}
+        {...(import.meta.env.DEV && { 'data-testid': 'new-session-button' })}
         className="w-full py-2.5 px-4 rounded-[20px] text-sm font-medium
           bg-accent hover:bg-accent-hover text-text-inverse
           hover:shadow-glow transition-smooth mb-4
@@ -104,7 +105,8 @@ export function Sidebar() {
       {/* Current Session — compressed single-line card */}
       {sessionMeta.sessionId && (
         <div className="px-3 py-2 rounded-xl bg-bg-secondary border border-border-subtle mb-3
-          flex items-center gap-2">
+          flex items-center gap-2"
+          {...(import.meta.env.DEV && { 'data-testid': 'current-session-card' })}>
           <span className={`w-2 h-2 rounded-full flex-shrink-0 transition-smooth
             ${sessionStatus === 'running'
               ? 'bg-success shadow-[0_0_8px_var(--color-accent-glow)] animate-pulse-soft'
@@ -135,6 +137,7 @@ export function Sidebar() {
       {/* Footer */}
       <div className="pt-3 mt-3 border-t border-border-subtle px-3">
         <button onClick={toggleSettings}
+          {...(import.meta.env.DEV && { 'data-testid': 'settings-button' })}
           className="w-full flex items-center gap-2.5 px-3 py-2 rounded-xl
             text-sm text-text-muted hover:bg-bg-secondary hover:text-text-primary
             transition-smooth">

--- a/src/components/settings/ProviderCard.tsx
+++ b/src/components/settings/ProviderCard.tsx
@@ -44,6 +44,7 @@ export function ProviderCard({
   return (
     <div
       onClick={onActivate}
+      {...(import.meta.env.DEV && { 'data-testid': `provider-card-${provider.id}` })}
       className={`group flex items-center gap-2.5 px-3 py-2.5 rounded-lg transition-smooth cursor-pointer
         ${isEditing
           ? 'bg-bg-secondary border border-accent/30'

--- a/src/components/settings/ProviderManager.tsx
+++ b/src/components/settings/ProviderManager.tsx
@@ -213,6 +213,7 @@ export function ProviderManager({ alwaysExpanded = false }: { alwaysExpanded?: b
           >
             <button
               onClick={() => setActive(null)}
+              {...(import.meta.env.DEV && { 'data-testid': 'provider-inherit-button' })}
               className={`text-left w-full px-3 py-2 ${!activeProviderId ? 'text-accent' : 'text-text-muted'}`}
             >
               {t('provider.inherit')}

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -81,7 +81,8 @@ export function SettingsPanel() {
       {/* Panel */}
       <div className="relative w-[min(90vw,960px)] max-h-[85vh] min-h-[500px]
         rounded-2xl bg-bg-card border border-border-subtle shadow-2xl
-        overflow-hidden animate-fade-in flex flex-col">
+        overflow-hidden animate-fade-in flex flex-col"
+        {...(import.meta.env.DEV && { 'data-testid': 'settings-panel' })}>
 
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4
@@ -90,6 +91,7 @@ export function SettingsPanel() {
             {t('settings.title')}
           </h2>
           <button onClick={toggleSettings}
+            {...(import.meta.env.DEV && { 'data-testid': 'settings-close-button' })}
             className="p-1.5 rounded-lg hover:bg-bg-tertiary
               text-text-tertiary transition-smooth">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none"
@@ -107,6 +109,7 @@ export function SettingsPanel() {
               <button
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
+                {...(import.meta.env.DEV && { 'data-testid': `settings-tab-${tab.id}` })}
                 className={`w-full flex items-center gap-1.5 px-2.5 py-2 rounded-lg text-[13px]
                   font-medium transition-smooth text-left whitespace-nowrap
                   ${activeTab === tab.id


### PR DESCRIPTION
## Summary

Add a socket-based E2E test harness that enables automated GUI testing of TOKENICODE from the command line. All infrastructure is **dev-only** — completely stripped from release builds via `#[cfg(debug_assertions)]` (Rust) and `import.meta.env.DEV` (JS).

This enables:
- Automated regression testing against real Claude CLI interactions
- CI-friendly test execution (no manual clicking)
- Reproducible bug verification with structured JSON reports

## Architecture

```
CLI (tokenicode-cli.mjs)
  → Unix socket (/tmp/tokenicode-test.sock)
    → Rust (tauri-plugin-mcp, debug builds only)
      → Tauri event system (execute-js)
        → Frontend JS (window.__tokenicode_test)
          → Zustand stores (direct state manipulation)
```

## What's included

### Rust backend
- `tauri-plugin-mcp` dependency (git, gated by `debug_assertions`)
- Socket server registration in `lib.rs::run()` — starts on `/tmp/tokenicode-test.sock`

### Frontend (19 files modified)
- `window.__tokenicode_test`: 20+ helper methods (getMessages, status, type, send, stop, switchSession, switchModel, newSession, deleteCurrentSession, etc.)
- `setupPluginListeners()`: registers the execute-js event bridge
- `data-testid` attributes on 15+ key UI elements (chat-messages, send-button, stop-button, model-selector, permission-card, settings-panel, session-item, etc.)
- Handler registrations: `__tokenicode_send`, `__tokenicode_editor`, `__tokenicode_respond_permission`

### CLI tools (2 new files)
- **`scripts/tokenicode-cli.mjs`** — 31 commands: ping, status, type, send, stop, delete-session, get-messages, wait-until-done, wait-for-phase, screenshot, query-page, exec, restart, relaunch, etc. Zero external dependencies.
- **`scripts/run-tests.mjs`** — Batch test runner: serial execution, auto-retry, timeout enforcement, structured JSON reports, automatic restart on 3 consecutive failures.

### Test data (gitignored)
Test suite definitions and run reports live in `.test/` (added to `.gitignore`). Documentation: `.test/README.md` and `.test/CLI-TEST-TOOL.md`.

## Security

- Socket server: `#[cfg(debug_assertions)]` — release builds don't compile it
- `data-testid` attributes: `import.meta.env.DEV` — production builds strip them
- `window.__tokenicode_test`: `import.meta.env.DEV` — not available in production
- `setupPluginListeners`: dynamic import inside `import.meta.env.DEV` check

## Test plan

- [x] `pnpm build` passes (TypeScript + Vite)
- [x] `cargo check` passes
- [x] Dev build: `node scripts/tokenicode-cli.mjs ping` returns `{"ok":true,"pong":true}`
- [x] Dev build: `node scripts/tokenicode-cli.mjs status` returns full state snapshot
- [x] Health suite: 10/10 pass
- [x] Basic chat suite: 4/4 pass (send, multi-turn, streaming, empty message)
- [x] Interrupt recovery suite: 4/4 pass (#80 regression)
- [ ] Release build: verify no test harness code is included