### PR TITLE
fix: clamp haiku effort level to prevent budget_tokens API errors

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1312,7 +1312,19 @@ async fn start_claude_session(
     args.push("stdio".to_string());
 
     // Extended thinking + effort level
+    // Haiku 4.5 has a narrower budget_tokens range (max 16384). Higher effort
+    // levels require more budget_tokens, causing API errors. Clamp to "low".
     let thinking_level = params.thinking_level.as_deref().unwrap_or("high");
+    let model_lower = params.model.as_deref().unwrap_or("").to_lowercase();
+    let thinking_level = if model_lower.contains("haiku") && thinking_level != "off" && thinking_level != "low" {
+        eprintln!(
+            "[TOKENICODE] Clamping effort level from '{}' to 'low' for haiku model",
+            thinking_level
+        );
+        "low"
+    } else {
+        thinking_level
+    };
     if thinking_level == "off" {
         // Explicitly disable thinking — CLI defaults to enabled, so we must pass false
         args.push("--settings".to_string());


### PR DESCRIPTION
## Summary

Haiku 4.5 (`claude-haiku-4-5-20251001`) has a `budget_tokens` ceiling of 16384. When TOKENICODE's thinking level is set to medium/high/max, the `CLAUDE_CODE_EFFORT_LEVEL` env var causes the CLI to request budget exceeding this limit, resulting in API 400 errors and an **80-90% streaming failure rate** for haiku.

## Root cause

`start_claude_session` in `lib.rs` passes the user's thinking level directly to the CLI as `CLAUDE_CODE_EFFORT_LEVEL` without model-specific validation. Haiku's budget_tokens range is narrower than Sonnet/Opus, so effort levels above "low" exceed the API's accepted range.

## Fix

Detect haiku models by checking if the model name contains "haiku" (case-insensitive). If the thinking level is anything above "low" (but not "off"), clamp it to "low" before spawning the CLI. Log the clamping for debugging visibility.

```rust
let thinking_level = if model_lower.contains("haiku")
    && thinking_level != "off" && thinking_level != "low" {
    eprintln!("[TOKENICODE] Clamping effort level from '{}' to 'low' for haiku model", thinking_level);
    "low"
} else {
    thinking_level
};
```

## Changed files

- `src-tauri/src/lib.rs` — 12 lines added in `start_claude_session`

## Test plan

- [x] `cargo check` passes
- [x] Haiku model: send message with thinking level "high" → response streams normally (was: 80-90% timeout)
- [x] Sonnet/Opus models: unaffected, effort level passed through unchanged
- [x] Thinking level "off": unaffected, still disables thinking entirely