### PR TITLE
fix: stale process_exit guard prevents interrupt-then-send message loss (#80)

### DIFF
--- a/src/hooks/useStreamProcessor.ts
+++ b/src/hooks/useStreamProcessor.ts
@@ -209,6 +209,15 @@ function _scheduleStreamFlush(stdinId: string) {
   });
 }
 
+/** Discard a stale session's stream buffer without flushing to UI.
+ *  Use in stale stdinId guards to prevent cross-session partial text pollution. */
+function discardStreamBuffer(stdinId: string) {
+  const buf = _streamBuffers.get(stdinId);
+  if (!buf) return;
+  if (buf.raf) cancelAnimationFrame(buf.raf);
+  _streamBuffers.delete(stdinId);
+}
+
 /** Flush any buffered streaming text immediately (call before clearPartial).
  *  If stdinId is provided, flush only that session's buffer.
  *  If omitted, flush ALL buffers (backward compat). */
@@ -2029,6 +2038,14 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
       }
 
       case 'process_exit': {
+        // --- Stale stdinId guard: don't clobber state if a newer session is already active ---
+        const currentStdinId_exit = useChatStore.getState().getTab(tabId)?.sessionMeta?.stdinId;
+        if (currentStdinId_exit && msg.__stdinId && currentStdinId_exit !== msg.__stdinId) {
+          console.warn('[TOKENICODE:session] Stale process_exit ignored:', msg.__stdinId, '!= current', currentStdinId_exit);
+          discardStreamBuffer(msg.__stdinId);
+          break;
+        }
+
         // STEP 1: Force-flush the per-stdinId rAF stream buffer into
         // chatStore.partialText / partialThinking BEFORE reading them.
         // Otherwise the last few text_delta tokens that arrived just


### PR DESCRIPTION
## Summary

Fixes #80 — when the user interrupts a streaming response (Stop) and immediately sends a new message, the new message appears silently swallowed. The AI never responds, and `wait-until-done` returns "completed" in under 1 second (should take several seconds for a real response).

## Root cause

The old CLI process's `process_exit` event arrives **after** the new session has started. Without an ownership check, this stale event:
1. Flushes the old process's stream buffer (potentially polluting the new session's `partialText`)
2. Transitions the tab to `idle` status → the new session's streaming is effectively killed
3. Clears `partialText` → any text the new session was building is wiped

The race window is small (typically <1s between stop and new send), but **100% reproducible** in automated testing.

## Fix

Add a stale stdinId ownership check at the top of the foreground `process_exit` handler:

```typescript
const currentStdinId_exit = useChatStore.getState().getTab(tabId)?.sessionMeta?.stdinId;
if (currentStdinId_exit && msg.__stdinId && currentStdinId_exit !== msg.__stdinId) {
  console.warn('[TOKENICODE:session] Stale process_exit ignored:', msg.__stdinId);
  discardStreamBuffer(msg.__stdinId);
  break;
}
```

Also adds `discardStreamBuffer()` — a companion to `flushStreamBuffer()` that cleanly drops a stale session's rAF-buffered text without flushing it to the UI.

## Changed files

- `src/hooks/useStreamProcessor.ts` — 17 lines added (guard + discardStreamBuffer utility)

## Test plan

- [x] `pnpm build` passes
- [x] T01: writing-phase interrupt → stop → send new message → response received ✅
- [x] T02: thinking-phase interrupt → stop → send new message → response received ✅
- [x] T03: double interrupt stress test (interrupt twice, then send) → response received ✅
- [x] T04: stop on idle session → no error ✅
- [x] No regression on basic chat (send, multi-turn, streaming)