### PR TITLE
fix: prevent empty messages with invisible Unicode characters

### DIFF
--- a/src/components/chat/InputBar.tsx
+++ b/src/components/chat/InputBar.tsx
@@ -694,7 +694,8 @@ export function InputBar() {
       useCommandStore.getState().clearPrefix();
     }
 
-    if (!text) return;
+    // Check if text is visually empty (strip invisible Unicode chars for the check only)
+    if (!text.replace(/[\u200B-\u200D\uFEFF\u00A0\u2060\u200E\u200F]/g, '').trim()) return;
 
     // Intercept immediate (built-in) commands even when submitted directly
     // (e.g. user types "/help" and presses Enter without using the popover)


### PR DESCRIPTION
## Summary

TipTap editor can produce visually empty content containing invisible Unicode characters (zero-width spaces, byte order marks, non-breaking spaces, etc.). The previous emptiness check `if (!text) return` only caught truly empty strings, allowing these "ghost" messages to be sent to the CLI — resulting in a user message bubble with no visible content.

## Fix

Strip known invisible Unicode characters before the emptiness check. The original text is preserved for actual sending — only the check uses the stripped version.

```typescript
// Before
if (!text) return;

// After
if (!text.replace(/[\u200B-\u200D\uFEFF\u00A0\u2060\u200E\u200F]/g, '').trim()) return;
```

Characters filtered: U+200B (zero-width space), U+200C (zero-width non-joiner), U+200D (zero-width joiner), U+FEFF (BOM), U+00A0 (non-breaking space), U+2060 (word joiner), U+200E/F (LTR/RTL marks).

## Changed files

- `src/components/chat/InputBar.tsx` — 1 line changed

## Test plan

- [x] `pnpm build` passes
- [x] Empty editor → send button click → no message sent ✅
- [x] Editor with only zero-width spaces → send → no message sent ✅
- [x] Normal text → send → message sent normally ✅