### PR TITLE
fix: filter CLI internal protocol text from user-visible messages

### DIFF
--- a/src/hooks/useStreamProcessor.ts
+++ b/src/hooks/useStreamProcessor.ts
@@ -9,6 +9,14 @@ import { envFingerprint, resolveModelForProvider } from '../lib/api-provider';
 import { useProviderStore } from '../stores/providerStore';
 import { t } from '../lib/i18n';
 
+// --- CLI internal result strings that should not be rendered to users ---
+// These are protocol-level responses from the Claude CLI SDK control protocol.
+// They appear as msg.result or block.text in stream events but are not user content.
+const CLI_INTERNAL_RESULTS = new Set([
+  'No response requested.',
+  '[Tool result missing due to internal error]',
+]);
+
 // --- Error classification for user-facing messages ---
 // Each pattern maps to a friendly i18n key. Matched errors show the friendly
 // message as primary text with raw error in a collapsible details block.
@@ -515,6 +523,7 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
           const block = content[blockIdx];
           if (block.type === 'text') {
             if (bgHasAskUserQuestion) continue;
+            if (CLI_INTERNAL_RESULTS.has(block.text)) continue;
             const textId = msg.uuid ? `${msg.uuid}_text_${blockIdx}` : generateMessageId();
             store.addMessage(tabId, {
               id: textId,
@@ -680,7 +689,7 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
             lastProgressAt: undefined,
           });
         }
-        if (typeof msg.result === 'string' && msg.result) {
+        if (typeof msg.result === 'string' && msg.result && !CLI_INTERNAL_RESULTS.has(msg.result)) {
           // Only add if not already delivered via 'assistant' event
           const bgTab = store.getTab(tabId);
           const bgIsDuplicate = bgTab?.messages.some(
@@ -1293,6 +1302,7 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
           const block = content[blockIdx];
           if (block.type === 'text') {
             if (hasAskUserQuestion) continue;
+            if (CLI_INTERNAL_RESULTS.has(block.text)) continue;
             setActivityStatus({ phase: 'writing' });
             agentActions.updatePhase(agentId, 'writing');
             // Use msg.uuid + block index as stable ID so re-delivered
@@ -1778,7 +1788,7 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
         // Mark pending processing card (CLI slash command) as completed
         const pendingCmdMsgId = useChatStore.getState().getTab(tabId)?.sessionMeta.pendingCommandMsgId;
         if (pendingCmdMsgId) {
-          const resultOutput = typeof msg.result === 'string' ? msg.result : '';
+          const resultOutput = typeof msg.result === 'string' && !CLI_INTERNAL_RESULTS.has(msg.result) ? msg.result : '';
           useChatStore.getState().updateMessage(tabId, pendingCmdMsgId, {
             commandCompleted: true,
             commandData: {
@@ -1792,7 +1802,7 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
 
         // Extract result text for display (e.g., slash command output)
         let resultDisplayText = '';
-        if (typeof msg.result === 'string' && msg.result) {
+        if (typeof msg.result === 'string' && msg.result && !CLI_INTERNAL_RESULTS.has(msg.result)) {
           resultDisplayText = msg.result;
         } else if (typeof msg.content === 'string' && msg.content) {
           resultDisplayText = msg.content;


### PR DESCRIPTION
## Summary

The Claude CLI SDK control protocol emits internal strings like `"No response requested."` as result events and assistant content blocks. These protocol-level messages were being rendered as visible assistant message bubbles in the chat UI.

**Most commonly triggered** by interrupting the AI early (during thinking phase) — the CLI sends `"No response requested."` as the result, which appeared as the assistant's "reply" to the user.

## Root cause

The stream processor adds `msg.result` and `block.text` content to the message list without checking whether the text is a CLI internal protocol string. The strings come from CLI constants:
- `iH6 = "No response requested."` — sent when a control protocol request needs no response
- `gPY = "[Tool result missing due to internal error]"` — sent on internal tool failures

These constants were verified against Claude CLI 2.1.94 source (`cli.js:5138`).

## Fix

Add a `CLI_INTERNAL_RESULTS` Set at module level and filter at all **5 locations** where CLI output text enters the message pipeline:

| Location | Path | What it filters |
|----------|------|-----------------|
| Background result handler | `msg.result` check (~line 698) | Result event text |
| Foreground result handler | `msg.result` check (~line 1810) | Result event text |
| Command output assignment | `resultOutput` (~line 1796) | CommandProcessingCard output |
| Background assistant blocks | `block.text` check (~line 531) | Content block text |
| Foreground assistant blocks | `block.text` check (~line 1309) | Content block text |

```typescript
const CLI_INTERNAL_RESULTS = new Set([
  'No response requested.',
  '[Tool result missing due to internal error]',
]);
```

## Changed files

- `src/hooks/useStreamProcessor.ts` — 13 lines added

## Test plan

- [x] `pnpm build` passes
- [x] Early interrupt (thinking phase) → no "No response requested." visible ✅
- [x] Delayed interrupt (500ms into thinking) → no internal text visible ✅  
- [x] Interrupt → send new message → response clean, no internal text ✅
- [x] Normal responses unaffected (filter is exact string match only)