### PR TITLE
fix: strengthen LRU tab eviction to protect streaming content

### DIFF
--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -583,7 +583,7 @@ export const useChatStore = create<ChatState>()((set, get) => ({
         if (oldest === undefined) break;
         if (oldest === tabId) continue; // don't evict the tab we're creating
         const entry = newTabs.get(oldest);
-        if (entry?.isStreaming || entry?.sessionStatus === 'running') continue; // protect active
+        if (entry?.isStreaming || entry?.sessionStatus === 'running' || entry?.sessionStatus === 'reconnecting' || entry?.partialText || entry?.partialThinking) continue; // protect active
         newTabs.delete(oldest);
       }
       // If all candidates are streaming, allow cache to exceed MAX_CACHE


### PR DESCRIPTION
## Summary

The tab cache eviction in `ensureTab` (`MAX_CACHE=8`) could evict a tab that was actively receiving streaming content. This caused users to lose partial AI responses when switching between many session tabs.

## Root cause

The eviction guard only checked `isStreaming` and `sessionStatus === 'running'`. Two gaps:

1. **Buffer timing gap**: Between the first `text_delta` arriving and the rAF-throttled buffer flushing to `partialText`, the `isStreaming` flag isn't set yet. During this window, the tab looks "idle" to the eviction logic.
2. **Reconnecting state**: The stream watchdog auto-recovery transitions tabs to `'reconnecting'` before killing and restarting the CLI. This state wasn't protected.

## Fix

Expand the eviction guard to also check:
- `sessionStatus === 'reconnecting'`
- `partialText` is non-empty (streaming text buffered but not yet committed)
- `partialThinking` is non-empty (thinking content in progress)

```typescript
// Before
if (entry?.isStreaming || entry?.sessionStatus === 'running') continue;

// After
if (entry?.isStreaming || entry?.sessionStatus === 'running'
    || entry?.sessionStatus === 'reconnecting'
    || entry?.partialText || entry?.partialThinking) continue;
```

The existing fallback ("allow cache to exceed MAX_CACHE") handles the edge case where all 8+ tabs are protected. Tabs become evictable again once streaming completes and `partialText` is cleared by `setSessionStatus`.

## Changed files

- `src/stores/chatStore.ts` — 1 line changed

## Test plan

- [x] `pnpm build` passes
- [x] Switch between 10+ sessions while one is streaming → partial text preserved ✅
- [x] Normal tab eviction still works for idle sessions ✅
- [x] No regression on basic chat or interrupt recovery