### PR TITLE
feat(provider): add CC Switch coexistence notice

### DIFF
--- a/src/components/settings/ProviderManager.tsx
+++ b/src/components/settings/ProviderManager.tsx
@@ -204,6 +204,11 @@ export function ProviderManager({ alwaysExpanded = false }: { alwaysExpanded?: b
 
       {isExpanded && (
         <div className="space-y-3 ml-0">
+          {/* CC Switch coexistence notice */}
+          <div className="rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-[12px] text-warning">
+            {t('provider.ccswitchNotice')}
+          </div>
+
           {/* Inherit system config option */}
           <div className={`rounded-lg text-[13px] transition-smooth border
             ${!activeProviderId

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -363,6 +363,7 @@ const messages: Record<Locale, Record<string, string>> = {
 
     // Provider
     'provider.title': 'API 提供商',
+    'provider.ccswitchNotice': '如果打开 CC Switch，请使用「继承系统配置」。',
     'provider.inherit': '继承系统配置',
     'provider.inheritDesc': '使用外部工具（如 CC-Switch）或系统环境变量的配置',
     'provider.addNew': '新增提供商',
@@ -1071,6 +1072,7 @@ const messages: Record<Locale, Record<string, string>> = {
 
     // Provider
     'provider.title': 'API Provider',
+    'provider.ccswitchNotice': 'If CC Switch is enabled, please use "System Config".',
     'provider.inherit': 'System Config',
     'provider.inheritDesc': 'Use external tools (e.g. CC-Switch) or system environment variables',
     'provider.addNew': 'Add Provider',


### PR DESCRIPTION
## Summary

- Mirrors Her-Desktop Phase A policy change: drop CC Switch compatibility for the in-app third-party provider list. Keep coexistence only for "继承系统配置" (inherit) mode.
- Persistent notice at top of Provider panel: "如果打开 CC Switch，请使用「继承系统配置」。" — shown whenever the panel is expanded.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [ ] Manual: open settings → API Provider, notice visible at top in both zh-CN and en-US