### PR TITLE
fix(phase-b): collision-safe interrupted IDs + agentCache GC on delete

### DIFF
--- a/src/components/chat/InputBar.tsx
+++ b/src/components/chat/InputBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { useChatStore, useActiveTab, getActiveTabState, generateMessageId } from '../../stores/chatStore';
+import { useChatStore, useActiveTab, getActiveTabState, generateMessageId, generateInterruptedId } from '../../stores/chatStore';
 import { useSettingsStore, MODEL_OPTIONS, mapSessionModeToPermissionMode, setSessionModeLocal, type ThinkingLevel } from '../../stores/settingsStore';
 import { bridge, onClaudeStream, onClaudeStderr, onSessionExit, onPermissionRequest, type UnifiedCommand, type PermissionRequest } from '../../lib/tauri-bridge';
 import { ModelSelector } from './ModelSelector';
@@ -1477,7 +1477,7 @@ export function InputBar() {
                   const stopPThinking = stopTab?.partialThinking ?? '';
                   if (stopPThinking.trim().length > 0) {
                     useChatStore.getState().addMessage(stopTabId, {
-                      id: `interrupted_thinking_${Date.now()}`,
+                      id: generateInterruptedId('thinking'),
                       role: 'assistant',
                       type: 'thinking',
                       content: stopPThinking,
@@ -1486,7 +1486,7 @@ export function InputBar() {
                   }
                   if (stopPText.trim().length > 0) {
                     useChatStore.getState().addMessage(stopTabId, {
-                      id: `interrupted_text_${Date.now()}`,
+                      id: generateInterruptedId('text'),
                       role: 'assistant',
                       type: 'text',
                       content: stopPText,

--- a/src/components/conversations/ConversationList.tsx
+++ b/src/components/conversations/ConversationList.tsx
@@ -400,6 +400,9 @@ export function ConversationList() {
         useSettingsStore.getState().setWorkingDirectory('');
       }
       useChatStore.getState().removeFromCache(sessionId);
+      // Drop the per-tab agent cache — otherwise creating a new session
+      // that reuses this ID shows the ghost agents of the old one (#B9).
+      useAgentStore.getState().clearCacheForTab(sessionId);
       fetchSessions();
     } catch (err) {
       console.error('Failed to delete session:', err);

--- a/src/hooks/useStreamProcessor.ts
+++ b/src/hooks/useStreamProcessor.ts
@@ -1,5 +1,5 @@
 import { useCallback, type MutableRefObject } from 'react';
-import { useChatStore, generateMessageId, type ChatMessage } from '../stores/chatStore';
+import { useChatStore, generateMessageId, generateInterruptedId, type ChatMessage } from '../stores/chatStore';
 import { useSettingsStore, mapSessionModeToPermissionMode, getEffectiveMode } from '../stores/settingsStore';
 import { useSessionStore, setOrphanDrainCallback } from '../stores/sessionStore';
 import { useAgentStore, resolveAgentId, getAgentDepth } from '../stores/agentStore';
@@ -787,7 +787,7 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
           const bgText = bgTab?.partialText ?? '';
           if (bgThinking.trim().length > 0) {
             store.addMessage(tabId, {
-              id: `interrupted_thinking_${Date.now()}`,
+              id: generateInterruptedId('thinking'),
               role: 'assistant',
               type: 'thinking',
               content: bgThinking,
@@ -796,7 +796,7 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
           }
           if (bgText.trim().length > 0) {
             store.addMessage(tabId, {
-              id: `interrupted_text_${Date.now()}`,
+              id: generateInterruptedId('text'),
               role: 'assistant',
               type: 'text',
               content: bgText,
@@ -2069,7 +2069,7 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
           });
           if (pThinking.trim().length > 0) {
             addMessage({
-              id: `interrupted_thinking_${Date.now()}`,
+              id: generateInterruptedId('thinking'),
               role: 'assistant',
               type: 'thinking',
               content: pThinking,
@@ -2078,7 +2078,7 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
           }
           if (pText.trim().length > 0) {
             addMessage({
-              id: `interrupted_text_${Date.now()}`,
+              id: generateInterruptedId('text'),
               role: 'assistant',
               type: 'text',
               content: pText,

--- a/src/stores/__tests__/agentStore.test.ts
+++ b/src/stores/__tests__/agentStore.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAgentStore } from '../agentStore';
+
+function resetAgents() {
+  useAgentStore.setState({ agents: new Map(), agentCache: new Map() });
+}
+
+describe('agentStore', () => {
+  beforeEach(() => {
+    resetAgents();
+  });
+
+  describe('completeAll is idempotent', () => {
+    it('running agents move to completed; second call is a no-op', () => {
+      const s = useAgentStore.getState();
+      s.upsertAgent({
+        id: 'a1',
+        parentId: null,
+        description: 'main',
+        phase: 'thinking',
+        startTime: 1,
+        isMain: true,
+      });
+      s.upsertAgent({
+        id: 'a2',
+        parentId: 'a1',
+        description: 'sub',
+        phase: 'writing',
+        startTime: 2,
+        isMain: false,
+      });
+
+      useAgentStore.getState().completeAll();
+      const afterFirst = useAgentStore.getState().agents;
+      expect(afterFirst.get('a1')?.phase).toBe('completed');
+      expect(afterFirst.get('a2')?.phase).toBe('completed');
+      const snapshotRef = afterFirst;
+
+      useAgentStore.getState().completeAll();
+      const afterSecond = useAgentStore.getState().agents;
+      expect(afterSecond).toBe(snapshotRef);
+    });
+
+    it('does not re-stamp endTime on already-completed agents', () => {
+      const s = useAgentStore.getState();
+      s.upsertAgent({
+        id: 'done',
+        parentId: null,
+        description: 'main',
+        phase: 'completed',
+        startTime: 1,
+        endTime: 100,
+        isMain: true,
+      });
+      useAgentStore.getState().completeAll();
+      expect(useAgentStore.getState().agents.get('done')?.endTime).toBe(100);
+    });
+
+    it('error-phase agents are preserved', () => {
+      const s = useAgentStore.getState();
+      s.upsertAgent({
+        id: 'err',
+        parentId: null,
+        description: 'main',
+        phase: 'error',
+        startTime: 1,
+        isMain: true,
+      });
+      useAgentStore.getState().completeAll();
+      expect(useAgentStore.getState().agents.get('err')?.phase).toBe('error');
+    });
+  });
+
+  describe('clearCacheForTab (#B9)', () => {
+    it('drops cache entry for the target tab without touching others', () => {
+      const s = useAgentStore.getState();
+      s.upsertAgent({
+        id: 'a',
+        parentId: null,
+        description: 'A',
+        phase: 'thinking',
+        startTime: 1,
+        isMain: true,
+      });
+      s.saveToCache('tab-a');
+      s.clearAgents();
+      s.upsertAgent({
+        id: 'b',
+        parentId: null,
+        description: 'B',
+        phase: 'thinking',
+        startTime: 2,
+        isMain: true,
+      });
+      s.saveToCache('tab-b');
+
+      useAgentStore.getState().clearCacheForTab('tab-a');
+      const cache = useAgentStore.getState().agentCache;
+      expect(cache.has('tab-a')).toBe(false);
+      expect(cache.has('tab-b')).toBe(true);
+    });
+
+    it('no-op when tab has no cache entry', () => {
+      const before = useAgentStore.getState().agentCache;
+      useAgentStore.getState().clearCacheForTab('never-existed');
+      expect(useAgentStore.getState().agentCache).toBe(before);
+    });
+
+    it('fixes ghost-agent: delete+recreate with same tab id sees empty state', () => {
+      const s = useAgentStore.getState();
+      s.upsertAgent({
+        id: 'ghost',
+        parentId: null,
+        description: 'stale',
+        phase: 'thinking',
+        startTime: 1,
+        isMain: true,
+      });
+      s.saveToCache('tab-x');
+
+      useAgentStore.getState().clearCacheForTab('tab-x');
+
+      const restored = useAgentStore.getState().restoreFromCache('tab-x');
+      expect(restored).toBe(false);
+      expect(useAgentStore.getState().agents.size).toBe(0);
+    });
+  });
+});

--- a/src/stores/__tests__/interruptedId.test.ts
+++ b/src/stores/__tests__/interruptedId.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { generateInterruptedId } from '../chatStore';
+
+describe('generateInterruptedId (#B5)', () => {
+  it('carries the kind prefix', () => {
+    expect(generateInterruptedId('thinking')).toMatch(/^interrupted_thinking_/);
+    expect(generateInterruptedId('text')).toMatch(/^interrupted_text_/);
+  });
+
+  it('is unique under tight-loop generation in same tick', () => {
+    const n = 1000;
+    const ids = new Set<string>();
+    for (let i = 0; i < n; i++) {
+      ids.add(generateInterruptedId('thinking'));
+    }
+    expect(ids.size).toBe(n);
+  });
+
+  it('mixes kinds without collision', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 500; i++) {
+      ids.add(generateInterruptedId(i % 2 === 0 ? 'thinking' : 'text'));
+    }
+    expect(ids.size).toBe(500);
+  });
+});

--- a/src/stores/agentStore.ts
+++ b/src/stores/agentStore.ts
@@ -29,6 +29,8 @@ interface AgentState {
   saveToCache: (tabId: string) => void;
   /** Restore agents from cache for a tab (returns true if found) */
   restoreFromCache: (tabId: string) => boolean;
+  /** Drop per-tab cache entry (call when the session is deleted) — fixes #B9 ghost-agent on delete+recreate with same ID */
+  clearCacheForTab: (tabId: string) => void;
 }
 
 // --- Store ---
@@ -90,6 +92,14 @@ export const useAgentStore = create<AgentState>()((set, get) => ({
     }
     set({ agents: new Map(cached) });
     return true;
+  },
+
+  clearCacheForTab: (tabId) => {
+    const current = get().agentCache;
+    if (!current.has(tabId)) return;
+    const next = new Map(current);
+    next.delete(tabId);
+    set({ agentCache: next });
   },
 }));
 

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -252,6 +252,15 @@ export function generateMessageId(): string {
   return `msg_${Date.now()}_${messageCounter}`;
 }
 
+let interruptedCounter = 0;
+
+/** Unique ID for interrupted-content messages (thinking/text preserved on stop/exit).
+ *  Date.now() alone collides under high-concurrency interrupts (#B5). */
+export function generateInterruptedId(kind: 'thinking' | 'text'): string {
+  interruptedCounter += 1;
+  return `interrupted_${kind}_${Date.now()}_${interruptedCounter}`;
+}
+
 /** Default empty tab for when no tab is selected */
 const EMPTY_TAB: TabSession = {
   tabId: '',


### PR DESCRIPTION
## Summary

Overlay from [Her PR #185](https://github.com/yiliqi78/Her-Desktop/pull/185) — scoped subset of Phase B roadmap.

- **B5**: \`generateInterruptedId(kind)\` replaces \`interrupted_*_\${Date.now()}\` (collides when two interrupts fire in same ms). 6 call sites (useStreamProcessor ×4, InputBar ×2).
- **B9**: \`agentStore.clearCacheForTab()\` + ConversationList delete handler — stale per-tab agent cache caused ghost agents when a new session reused the deleted tab ID.

## Deferred

StreamController extraction, Rust process_supervisor, close_session watch-channel, tauri-bridge window isolation. Separate follow-up branch.

## Test plan

- [x] \`npx vitest run src/stores/__tests__/\` — 9/9 pass
- [x] \`tsc --noEmit\` clean
- [ ] Manual: delete session, new session same tab id → no ghost agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)