### PR TITLE
fix(phase-b): stream state scoping + close-path flush (B1/B2/B4/B8)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -306,6 +306,38 @@ function App() {
             cancelLabel: tRef.current('common.cancel'),
           });
           if (confirmed) {
+            // B8: flush in-flight streams and materialize any partial
+            // text/thinking as interrupted messages before we exit. Without
+            // this, users lose the last rAF-buffered delta (up to ~16ms of
+            // tokens) and any text/thinking already in partial state.
+            try {
+              const { flushStreamBuffer } = await import('./hooks/useStreamProcessor');
+              const { useChatStore: csMod, generateInterruptedId } = await import('./stores/chatStore');
+              flushStreamBuffer();
+              const cs = csMod.getState();
+              for (const [tabId, tab] of cs.tabs) {
+                if (tab.partialThinking && tab.partialThinking.trim().length > 0) {
+                  cs.addMessage(tabId, {
+                    id: generateInterruptedId('thinking'),
+                    role: 'assistant',
+                    type: 'thinking',
+                    content: tab.partialThinking,
+                    timestamp: Date.now(),
+                  });
+                }
+                if (tab.partialText && tab.partialText.trim().length > 0) {
+                  cs.addMessage(tabId, {
+                    id: generateInterruptedId('text'),
+                    role: 'assistant',
+                    type: 'text',
+                    content: tab.partialText,
+                    timestamp: Date.now(),
+                  });
+                }
+              }
+            } catch (err) {
+              console.warn('[TOKENICODE:close] stream flush failed', err);
+            }
             const { exit } = await import('@tauri-apps/plugin-process');
             await exit(0);
           }

--- a/src/components/chat/InputBar.tsx
+++ b/src/components/chat/InputBar.tsx
@@ -870,9 +870,12 @@ export function InputBar() {
             const tab = state.tabs.get(tabId);
             if (!tab) return {};
             const cleanedMessages = tab.messages.filter(m => m.type !== 'thinking');
-            if (cleanedMessages.length === tab.messages.length) return {};
+            const hadPartialThinking = !!tab.partialThinking;
+            if (cleanedMessages.length === tab.messages.length && !hadPartialThinking) return {};
             const newTabs = new Map(state.tabs);
-            newTabs.set(tabId, { ...tab, messages: cleanedMessages });
+            // B4: also pre-strip in-flight partialThinking — leaving it would resurface
+            // an old-model thinking fragment after resume kicks off, surprising the user.
+            newTabs.set(tabId, { ...tab, messages: cleanedMessages, partialThinking: '' });
             return { tabs: newTabs, sessionCache: newTabs };
           });
           stdinId = undefined;
@@ -900,9 +903,11 @@ export function InputBar() {
               const tab = state.tabs.get(tabId);
               if (!tab) return {};
               const cleanedMessages = tab.messages.filter(m => m.type !== 'thinking');
-              if (cleanedMessages.length === tab.messages.length) return {}; // nothing to clean
+              const hadPartialThinking = !!tab.partialThinking;
+              if (cleanedMessages.length === tab.messages.length && !hadPartialThinking) return {};
               const newTabs = new Map(state.tabs);
-              newTabs.set(tabId, { ...tab, messages: cleanedMessages });
+              // B4: also pre-strip in-flight partialThinking — see same rationale above.
+              newTabs.set(tabId, { ...tab, messages: cleanedMessages, partialThinking: '' });
               return { tabs: newTabs, sessionCache: newTabs };
             });
             stdinId = undefined;

--- a/src/hooks/__tests__/clearPartialScope.test.ts
+++ b/src/hooks/__tests__/clearPartialScope.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Phase B — B1 + B2: clearPartial scoping & flush-before-clear atomicity.
+ *
+ * Regression:
+ *   Before the fix, the clearPartial() closure inside handleStreamMessage
+ *   called flushStreamBuffer() with NO stdinId argument, which flushed AND
+ *   deleted every active rAF buffer across every session. When tab A's turn
+ *   completed while tab B was mid-stream, tab B's buffered delta was wiped.
+ *   The per-tab zero that followed only touched tab A's partialText — but
+ *   the damage to B was already done.
+ *
+ *   The B2 side of the same fix guarantees atomicity: since flushStreamBuffer
+ *   also removes the entry from _streamBuffers, no late rAF callback can
+ *   repopulate the buffer between our flush and our partial zero.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../lib/tauri-bridge', () => ({
+  bridge: {
+    listSessions: vi.fn(() => Promise.resolve([])),
+    loadCustomPreviews: vi.fn(() => Promise.resolve({})),
+    saveCustomPreviews: vi.fn(() => Promise.resolve()),
+    trackSession: vi.fn(() => Promise.resolve()),
+  },
+  onClaudeStream: vi.fn(() => Promise.resolve(() => {})),
+  onClaudeStderr: vi.fn(() => Promise.resolve(() => {})),
+  onSessionExit: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+import { useChatStore } from '../../stores/chatStore';
+import { flushStreamBuffer } from '../useStreamProcessor';
+
+function resetChatStore() {
+  useChatStore.setState({ tabs: new Map(), sessionCache: new Map() });
+}
+
+describe('flushStreamBuffer — B1/B2 scoped contract', () => {
+  beforeEach(resetChatStore);
+
+  it('scoped flush does not throw and leaves chatStore partials for other tabs untouched', () => {
+    useChatStore.getState().ensureTab('desk_A');
+    useChatStore.getState().ensureTab('desk_B');
+    useChatStore.getState().updatePartialMessage('desk_A', 'from A');
+    useChatStore.getState().updatePartialMessage('desk_B', 'from B');
+
+    expect(() => flushStreamBuffer('stdin_unrelated')).not.toThrow();
+    expect(useChatStore.getState().getTab('desk_A')?.partialText).toBe('from A');
+    expect(useChatStore.getState().getTab('desk_B')?.partialText).toBe('from B');
+  });
+
+  it('unscoped flush (no arg) is still available for shutdown paths (B8)', () => {
+    // B8: App.tsx close handler relies on the unscoped form to drain
+    // everything before exit. Keep this contract working.
+    expect(() => flushStreamBuffer()).not.toThrow();
+  });
+});

--- a/src/hooks/useStreamProcessor.ts
+++ b/src/hooks/useStreamProcessor.ts
@@ -1065,10 +1065,15 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
       }
     }
 
-    // Helper: clear accumulated partial text (it will be replaced by the full message)
+    // Helper: clear accumulated partial text for THIS tab only.
+    // B1: flush must be scoped to msgStdinId — calling flushStreamBuffer() with
+    //     no args previously wiped every active session's rAF buffer, causing
+    //     cross-tab data loss when one tab's turn completed while another was
+    //     streaming. B2: buffer drop happens inside flushStreamBuffer (delete
+    //     from _streamBuffers) so no late rAF can repopulate this tab's partial
+    //     after we clear it below — flush → clear is atomic w.r.t. this tab.
     const clearPartial = () => {
-      // Flush any buffered text so the final tokens aren't lost
-      flushStreamBuffer();
+      if (msgStdinId) flushStreamBuffer(msgStdinId);
       const tabData = useChatStore.getState().getTab(tabId);
       if (tabData && (tabData.isStreaming || tabData.partialText || tabData.partialThinking)) {
         const newTabs = new Map(useChatStore.getState().tabs);


### PR DESCRIPTION
Overlay of Her #186. Four bugfixes: B1/B2 (clearPartial stdinId scope), B4 (model-switch pre-strip partialThinking), B8 (close-path stream flush). Tests + typecheck green.