### PR TITLE
feat(phase-b): settingsEvents bus (B10)

### DIFF
--- a/src/lib/__tests__/settingsEvents.test.ts
+++ b/src/lib/__tests__/settingsEvents.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Phase B · B10 — settings event bus.
+ *
+ * Regression guarded here:
+ *   Before this bus existed, settingsStore.setSelectedModel / setThinkingLevel
+ *   / setSessionMode were pure state writes. Running streams that had already
+ *   captured a turn-start snapshot never learned the user had changed the
+ *   setting, so the next retry/resume still used the stale value.
+ *
+ *   Roadmap §4.3.5 — settingsStore 事件化. This file pins down the contract.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Install an in-memory localStorage stub BEFORE settingsStore is imported —
+// zustand/persist captures the storage reference at module initialization.
+// vi.hoisted runs before ESM import resolution, which is the only place this
+// setup can land in time.
+vi.hoisted(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => { store.set(k, String(v)); },
+      removeItem: (k: string) => { store.delete(k); },
+      clear: () => store.clear(),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length() { return store.size; },
+    },
+    configurable: true,
+  });
+});
+
+vi.mock('../tauri-bridge', () => ({
+  bridge: {
+    listSessions: vi.fn(() => Promise.resolve([])),
+    loadCustomPreviews: vi.fn(() => Promise.resolve({})),
+    saveCustomPreviews: vi.fn(() => Promise.resolve()),
+    setPermissionMode: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+// settingsStore subscribes to sessionMode changes and dynamically imports
+// chatStore + sessionStore to push set_permission_mode to the live CLI session.
+// In unit-test environment those dynamic imports can resolve AFTER the test
+// environment is torn down, which surfaces as an unhandled rejection. Stub the
+// transitive modules so the promise chain resolves synchronously with no-ops.
+vi.mock('../../stores/chatStore', () => ({
+  useChatStore: { getState: () => ({ setSessionMeta: () => {} }) },
+  getActiveTabState: () => ({ sessionMeta: {} }),
+}));
+vi.mock('../../stores/sessionStore', () => ({
+  useSessionStore: {
+    getState: () => ({
+      getSessionByStdinId: () => undefined,
+      selectedSessionId: null,
+    }),
+  },
+}));
+
+import { settingsEvents } from '../settingsEvents';
+import { useSettingsStore } from '../../stores/settingsStore';
+
+describe('settingsEvents · emitter contract', () => {
+  beforeEach(() => {
+    settingsEvents._reset();
+  });
+
+  it('on/off round-trip: unsubscribe stops subsequent calls', () => {
+    const handler = vi.fn();
+    const off = settingsEvents.on('model-changed', handler);
+    settingsEvents.emit('model-changed', { old: 'a', next: 'b' });
+    off();
+    settingsEvents.emit('model-changed', { old: 'b', next: 'c' });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ old: 'a', next: 'b' });
+  });
+
+  it('a throwing handler does not break other listeners', () => {
+    const bad = vi.fn(() => { throw new Error('boom'); });
+    const good = vi.fn();
+    settingsEvents.on('thinking-changed', bad);
+    settingsEvents.on('thinking-changed', good);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    settingsEvents.emit('thinking-changed', { old: 'off', next: 'high' });
+    expect(bad).toHaveBeenCalled();
+    expect(good).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('events stay typed and independent per channel', () => {
+    const modelH = vi.fn();
+    const thinkingH = vi.fn();
+    settingsEvents.on('model-changed', modelH);
+    settingsEvents.on('thinking-changed', thinkingH);
+    settingsEvents.emit('model-changed', { old: 'x', next: 'y' });
+    expect(modelH).toHaveBeenCalledTimes(1);
+    expect(thinkingH).not.toHaveBeenCalled();
+  });
+});
+
+describe('settingsStore setters · emit on change', () => {
+  beforeEach(() => {
+    settingsEvents._reset();
+  });
+
+  it('setSelectedModel fires model-changed with old+next', () => {
+    const h = vi.fn();
+    settingsEvents.on('model-changed', h);
+    const initial = useSettingsStore.getState().selectedModel;
+    useSettingsStore.getState().setSelectedModel('claude-haiku-4-5-20251001');
+    expect(h).toHaveBeenCalledTimes(1);
+    expect(h).toHaveBeenCalledWith({ old: initial, next: 'claude-haiku-4-5-20251001' });
+    // Restore
+    useSettingsStore.getState().setSelectedModel(initial);
+  });
+
+  it('setSelectedModel does NOT fire if value is unchanged', () => {
+    const h = vi.fn();
+    const current = useSettingsStore.getState().selectedModel;
+    settingsEvents.on('model-changed', h);
+    useSettingsStore.getState().setSelectedModel(current);
+    expect(h).not.toHaveBeenCalled();
+  });
+
+  it('setThinkingLevel fires thinking-changed', () => {
+    const h = vi.fn();
+    settingsEvents.on('thinking-changed', h);
+    const initial = useSettingsStore.getState().thinkingLevel;
+    const next = initial === 'high' ? 'low' : 'high';
+    useSettingsStore.getState().setThinkingLevel(next);
+    expect(h).toHaveBeenCalledTimes(1);
+    expect(h).toHaveBeenCalledWith({ old: initial, next });
+    useSettingsStore.getState().setThinkingLevel(initial);
+  });
+
+  it('setSessionMode fires session-mode-changed', () => {
+    const h = vi.fn();
+    settingsEvents.on('session-mode-changed', h);
+    const initial = useSettingsStore.getState().sessionMode;
+    const next = initial === 'code' ? 'ask' : 'code';
+    useSettingsStore.getState().setSessionMode(next);
+    expect(h).toHaveBeenCalledTimes(1);
+    expect(h).toHaveBeenCalledWith({ old: initial, next });
+    useSettingsStore.getState().setSessionMode(initial);
+  });
+});

--- a/src/lib/settingsEvents.ts
+++ b/src/lib/settingsEvents.ts
@@ -1,0 +1,62 @@
+/**
+ * Settings event bus (Phase B · B10).
+ *
+ * Why this exists:
+ *   settingsStore.setSelectedModel / setThinkingLevel / setSessionMode used to
+ *   be pure state writes. Running streams that captured a snapshot at turn
+ *   start would continue to use the old value even after the user changed it
+ *   in the UI. Without a pub/sub channel there is no way for the stream layer
+ *   (or any other consumer) to know it should re-snapshot.
+ *
+ *   See Her v0.5.2 roadmap §4.3.5 — "settingsStore 事件化".
+ *
+ * Design:
+ *   A minimal typed emitter with no runtime dependency. Subscribers are kept
+ *   in a Set so `off()` is O(1). Handler errors are isolated so one bad
+ *   listener cannot break the others.
+ */
+
+export type SettingsEventMap = {
+  'model-changed': { old: string; next: string };
+  'thinking-changed': { old: string; next: string };
+  'session-mode-changed': { old: string; next: string };
+};
+
+type EventName = keyof SettingsEventMap;
+type Handler<T extends EventName> = (payload: SettingsEventMap[T]) => void;
+
+class SettingsEmitter {
+  private handlers: { [K in EventName]: Set<Handler<K>> } = {
+    'model-changed': new Set(),
+    'thinking-changed': new Set(),
+    'session-mode-changed': new Set(),
+  };
+
+  on<T extends EventName>(event: T, handler: Handler<T>): () => void {
+    this.handlers[event].add(handler);
+    return () => this.handlers[event].delete(handler);
+  }
+
+  off<T extends EventName>(event: T, handler: Handler<T>): void {
+    this.handlers[event].delete(handler);
+  }
+
+  emit<T extends EventName>(event: T, payload: SettingsEventMap[T]): void {
+    for (const handler of this.handlers[event]) {
+      try {
+        handler(payload);
+      } catch (err) {
+        console.error(`[settingsEvents] handler for "${event}" threw:`, err);
+      }
+    }
+  }
+
+  /** Test-only: drop all subscribers. */
+  _reset(): void {
+    for (const key of Object.keys(this.handlers) as EventName[]) {
+      this.handlers[key].clear();
+    }
+  }
+}
+
+export const settingsEvents = new SettingsEmitter();

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { settingsEvents } from '../lib/settingsEvents';
 
 // --- Types ---
 
@@ -119,7 +120,7 @@ function nextTheme(current: Theme): Theme {
 
 export const useSettingsStore = create<SettingsState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       theme: 'system',
       colorTheme: 'black',
       sidebarOpen: true,
@@ -184,11 +185,17 @@ export const useSettingsStore = create<SettingsState>()(
       setWorkingDirectory: (dir) =>
         set(() => ({ workingDirectory: dir })),
 
-      setSelectedModel: (model) =>
-        set(() => ({ selectedModel: model })),
+      setSelectedModel: (model) => {
+        const old = get().selectedModel;
+        set(() => ({ selectedModel: model }));
+        if (old !== model) settingsEvents.emit('model-changed', { old, next: model });
+      },
 
-      setSessionMode: (mode) =>
-        set(() => ({ sessionMode: mode })),
+      setSessionMode: (mode) => {
+        const old = get().sessionMode;
+        set(() => ({ sessionMode: mode }));
+        if (old !== mode) settingsEvents.emit('session-mode-changed', { old, next: mode });
+      },
 
       setLocale: (locale) =>
         set(() => ({ locale })),
@@ -211,8 +218,11 @@ export const useSettingsStore = create<SettingsState>()(
       setSetupCompleted: (completed) =>
         set(() => ({ setupCompleted: completed })),
 
-      setThinkingLevel: (level) =>
-        set(() => ({ thinkingLevel: level })),
+      setThinkingLevel: (level) => {
+        const old = get().thinkingLevel;
+        set(() => ({ thinkingLevel: level }));
+        if (old !== level) settingsEvents.emit('thinking-changed', { old, next: level });
+      },
 
       setUpdateAvailable: (available, version) =>
         set(() => ({


### PR DESCRIPTION
## Summary
- settingsStore setters (`setSelectedModel` / `setSessionMode` / `setThinkingLevel`) were pure state writes. Running streams that captured a turn-start snapshot never learned the user had changed the setting, so retries/resumes would use stale values.
- Add `src/lib/settingsEvents.ts` — minimal typed emitter, no runtime deps. Consumers can subscribe to `model-changed` / `thinking-changed` / `session-mode-changed`.
- Setters now diff old vs next and emit only on actual change.

Roadmap §4.3.5 — settingsStore 事件化 (synced from Her).

## Test plan
- [x] `pnpm vitest run src/lib/__tests__/settingsEvents.test.ts` — 7/7 green
- [x] Full Vitest suite — 29/29 green
- [x] `pnpm tsc --noEmit` — clean