### PR TITLE
fix(chatStore): demote stale running status on restoreFromCache (B11)

### DIFF
--- a/src/stores/__tests__/chatStoreRestore.test.ts
+++ b/src/stores/__tests__/chatStoreRestore.test.ts
@@ -1,0 +1,114 @@
+/**
+ * B11 · restoreFromCache stale-running demotion.
+ *
+ * Regression guarded here:
+ *   Cached tab.sessionStatus could persist as 'running' when the underlying
+ *   process was gone (app restart, ProcessExit bypassed for background tab,
+ *   etc.). restoreFromCache then re-asserted runningSessions=true, so the
+ *   sidebar red dot never cleared. Fix: when there's no live process AND no
+ *   stdinId, demote the cached status to 'idle' before syncing.
+ *   Roadmap §4.3.7 / B11.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../sessionStore', () => {
+  const store = {
+    selectedSessionId: null as string | null,
+    sessions: [] as any[],
+    setSessionRunning: vi.fn(),
+    getTabForStdin: vi.fn(() => undefined),
+  };
+  return {
+    useSessionStore: {
+      getState: () => store,
+      __mock: store,
+    },
+  };
+});
+
+import { useChatStore } from '../chatStore';
+import { useSessionStore } from '../sessionStore';
+
+function msg(id: string, overrides: any = {}) {
+  return {
+    id,
+    role: 'assistant' as const,
+    type: 'text' as const,
+    content: 'test',
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('chatStore · B11 — stale-running demotion on restoreFromCache', () => {
+  beforeEach(() => {
+    useChatStore.setState({ tabs: new Map(), sessionCache: new Map() });
+    const mock = (useSessionStore as any).__mock;
+    mock.selectedSessionId = null;
+    mock.sessions = [];
+    mock.setSessionRunning.mockClear();
+  });
+
+  it('cached "running" with no live process → demotes to idle', () => {
+    const store = useChatStore.getState();
+    store.ensureTab('stale');
+    store.addMessage('stale', msg('m1'));
+    store.setSessionStatus('stale', 'running');
+    (useSessionStore as any).__mock.sessions = [{ id: 'stale', process: null }];
+    (useSessionStore as any).__mock.setSessionRunning.mockClear();
+
+    const ok = useChatStore.getState().restoreFromCache('stale');
+    expect(ok).toBe(true);
+
+    const tab = useChatStore.getState().getTab('stale');
+    expect(tab?.sessionStatus).toBe('idle');
+    expect(tab?.isStreaming).toBe(false);
+    expect(tab?.partialText).toBe('');
+
+    const calls = (useSessionStore as any).__mock.setSessionRunning.mock.calls;
+    expect(calls[calls.length - 1]).toEqual(['stale', false]);
+  });
+
+  it('cached "running" with live stdinId → keeps running state intact', () => {
+    const store = useChatStore.getState();
+    store.ensureTab('live');
+    store.addMessage('live', msg('m1'));
+    store.setSessionStatus('live', 'running');
+    store.setSessionMeta('live', { stdinId: 'sid-1' });
+    (useSessionStore as any).__mock.setSessionRunning.mockClear();
+
+    useChatStore.getState().restoreFromCache('live');
+
+    const tab = useChatStore.getState().getTab('live');
+    expect(tab?.sessionStatus).toBe('running');
+    const calls = (useSessionStore as any).__mock.setSessionRunning.mock.calls;
+    expect(calls[calls.length - 1]).toEqual(['live', true]);
+  });
+
+  it('cached "reconnecting" with no process also gets demoted', () => {
+    const store = useChatStore.getState();
+    store.ensureTab('recon');
+    store.addMessage('recon', msg('m1'));
+    store.setSessionStatus('recon', 'reconnecting');
+    (useSessionStore as any).__mock.sessions = [{ id: 'recon', process: null }];
+
+    useChatStore.getState().restoreFromCache('recon');
+    expect(useChatStore.getState().getTab('recon')?.sessionStatus).toBe('idle');
+  });
+
+  it('cached "idle" is never upgraded or touched', () => {
+    const store = useChatStore.getState();
+    store.ensureTab('done');
+    store.addMessage('done', msg('m1'));
+    store.setSessionStatus('done', 'idle');
+    (useSessionStore as any).__mock.sessions = [{ id: 'done', process: null }];
+    (useSessionStore as any).__mock.setSessionRunning.mockClear();
+
+    useChatStore.getState().restoreFromCache('done');
+
+    const tab = useChatStore.getState().getTab('done');
+    expect(tab?.sessionStatus).toBe('idle');
+    const calls = (useSessionStore as any).__mock.setSessionRunning.mock.calls;
+    expect(calls[calls.length - 1]).toEqual(['done', false]);
+  });
+});

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -647,6 +647,28 @@ export const useChatStore = create<ChatState>()((set, get) => ({
         });
       }
     }
+    // B11: cached status may say 'running'/'reconnecting' but the process is gone
+    // (e.g. app restart, or ProcessExit handler was bypassed for this tab).
+    // Live processes here are tracked by stdinId; if the tab has no stdinId bound,
+    // treat the cache as stale and demote to 'idle' so the sidebar red dot clears.
+    const cachedActive = tab.sessionStatus === 'running' || tab.sessionStatus === 'reconnecting';
+    if (cachedActive) {
+      const hasStdinId = Boolean(get().tabs.get(tabId)?.sessionMeta.stdinId);
+      if (!hasStdinId) {
+        set((state) => {
+          const result = updateTab(state.tabs, tabId, (t) => ({
+            ...t,
+            sessionStatus: 'idle',
+            isStreaming: false,
+            partialText: '',
+            partialThinking: '',
+          }));
+          return result ?? {};
+        });
+        useSessionStore.getState().setSessionRunning(tabId, false);
+        return true;
+      }
+    }
     // Sync running state to sessionStore for sidebar indicator (FI-1 fix)
     useSessionStore.getState().setSessionRunning(tabId, tab.sessionStatus === 'running');
     return true;


### PR DESCRIPTION
## Summary
- Demote cached `sessionStatus='running'` to `'idle'` in `restoreFromCache` when there's no live `stdinId` in the tab's sessionMeta
- Clears streaming/partial state and calls `setSessionRunning(tabId, false)` so the sidebar red dot resets

## Why
When a tab is restored from cache after an app restart (or ProcessExit was bypassed for a background tab), the cached sessionStatus can remain `'running'`. The old code re-asserted `runningSessions=true` unconditionally, leaving the sidebar red dot stuck on forever.

Note: TK uses `stdinToTab` map (no `session.process` field), so the check is stdinId-only — not a full process lookup like Her/Her-s.

## Roadmap
§4.3.7 / B11

## Test plan
- [x] `pnpm vitest run` — 33/33 green
- [x] `pnpm tsc --noEmit` — clean
- [ ] Manual: start a session, force-quit app, relaunch → red dot should clear on the restored tab