### PR TITLE
refactor(stream): overlay StreamController architecture (§4.3.1)

### DIFF
--- a/src/hooks/useStreamProcessor.ts
+++ b/src/hooks/useStreamProcessor.ts
@@ -33,96 +33,37 @@ export function formatErrorForUser(raw: string): string {
   return `${friendly}\n\n<details>\n<summary>${t('error.showDetails')}</summary>\n\n\`\`\`\n${raw}\n\`\`\`\n\n</details>`;
 }
 
-// --- Streaming text buffer (rAF-throttled + interval fallback, per-stdinId) ---
-// Coalesces rapid text_delta / thinking_delta events into a single state update
-// per animation frame (~60/s), preventing JS main thread starvation from
-// excessive React re-renders when the message list is large.
-//
-// CRITICAL: rAF alone is unreliable — heavy React re-renders can block the
-// rendering pipeline, preventing rAF callbacks from firing. A 200ms setInterval
-// fallback ensures buffered text is always flushed even when rAF is starved.
-//
-// TK-329 fix: each session gets its own buffer to prevent cross-contamination
-// when multiple sessions stream concurrently.
-interface _StreamBuffer {
-  text: string;
-  thinking: string;
-  raf: number;
-}
-const _streamBuffers = new Map<string, _StreamBuffer>();
+// --- Streaming text buffer ---
+// Ownership of the rAF buffer, orphan queue, and completion guard lives in
+// StreamController (src/stream/StreamController.ts). This module is now a
+// thin call-site for the singleton. See roadmap §4.3.1.
+import { streamController, DEFAULT_CONFIG as _STREAM_CONFIG } from '../stream/instance';
 
-// --- Orphan queue (#57-B) ---
-// When _doFlush fires after the stdinId has been unregistered AND
-// selectedSessionId is null, the previous code silently wiped the buffer.
-// Instead, stash the text in an orphan queue keyed by stdinId. The queue is
-// drained when registerStdinTab(stdinId, tabId) is later called.
-interface _OrphanEntry { text: string; thinking: string; expiresAt: number; }
-const _ORPHAN_TTL_MS = 5_000;
-const _ORPHAN_PER_STDIN_CAP_CHARS = 1 * 1024 * 1024;
-const _ORPHAN_TOTAL_CAP_CHARS = 10 * 1024 * 1024;
-const _orphanQueue = new Map<string, _OrphanEntry>();
-
-function _orphanTotalChars(): number {
-  let total = 0;
-  for (const entry of _orphanQueue.values()) total += entry.text.length + entry.thinking.length;
-  return total;
-}
-
-function _stashOrphan(stdinId: string, text: string, thinking: string) {
-  if (!text && !thinking) return;
-  _expireOrphans();
-  const existing = _orphanQueue.get(stdinId);
-  const merged: _OrphanEntry = existing
-    ? { text: existing.text + text, thinking: existing.thinking + thinking, expiresAt: Date.now() + _ORPHAN_TTL_MS }
-    : { text, thinking, expiresAt: Date.now() + _ORPHAN_TTL_MS };
-  const mergedChars = merged.text.length + merged.thinking.length;
-  if (mergedChars > _ORPHAN_PER_STDIN_CAP_CHARS) {
-    console.error('[stream-flush] orphan entry exceeds per-stdinId cap, dropping:', stdinId);
-    _orphanQueue.delete(stdinId);
-    return;
-  }
-  _orphanQueue.set(stdinId, merged);
-  if (_orphanTotalChars() > _ORPHAN_TOTAL_CAP_CHARS) {
-    while (_orphanTotalChars() > _ORPHAN_TOTAL_CAP_CHARS) {
-      const oldest = _orphanQueue.keys().next().value;
-      if (!oldest) break;
-      _orphanQueue.delete(oldest);
-    }
-  }
-}
-
-function _expireOrphans() {
-  const now = Date.now();
-  for (const [id, entry] of _orphanQueue.entries()) {
-    if (entry.expiresAt <= now) _orphanQueue.delete(id);
-  }
-}
-
-/** Drain any orphan buffer for the given stdinId into its newly known tab. */
+/** Drain any orphan buffer for the given stdinId into its newly known tab.
+ *  Called by sessionStore.registerStdinTab via the registered callback. */
 export function drainOrphanBuffer(stdinId: string, tabId: string) {
-  _expireOrphans();
-  const entry = _orphanQueue.get(stdinId);
-  if (!entry) return;
-  const store = useChatStore.getState();
-  if (entry.text) store.updatePartialMessage(tabId, entry.text);
-  if (entry.thinking) store.updatePartialThinking(tabId, entry.thinking);
-  _orphanQueue.delete(stdinId);
+  streamController.drainOrphan(stdinId, tabId);
 }
 
-/** Test-only seam for B3 orphan-queue regression coverage. Not part of the
+/** Test-only seam for orphan-queue regression coverage. Not part of the
  *  runtime API surface — do not import from production code. */
 export const __orphanTesting = {
-  stash: _stashOrphan,
-  expire: _expireOrphans,
-  size: (): number => _orphanQueue.size,
-  has: (stdinId: string): boolean => _orphanQueue.has(stdinId),
-  get: (stdinId: string) => _orphanQueue.get(stdinId),
-  clear: () => _orphanQueue.clear(),
-  totalChars: _orphanTotalChars,
-  TTL_MS: _ORPHAN_TTL_MS,
-  PER_STDIN_CAP: _ORPHAN_PER_STDIN_CAP_CHARS,
-  TOTAL_CAP: _ORPHAN_TOTAL_CAP_CHARS,
+  stash: (stdinId: string, text: string, thinking: string) =>
+    streamController.stashOrphan(stdinId, text, thinking),
+  expire: () => streamController.expireOrphans(),
+  size: (): number => streamController.__testing.orphansSize(),
+  has: (stdinId: string): boolean => streamController.__testing.hasOrphan(stdinId),
+  get: (stdinId: string) => streamController.__testing.getOrphan(stdinId),
+  clear: () => streamController.__testing.clear(),
+  totalChars: (): number => streamController.__testing.orphanTotalChars(),
+  TTL_MS: _STREAM_CONFIG.ttlMs,
+  PER_STDIN_CAP: _STREAM_CONFIG.perStdinCapChars,
+  TOTAL_CAP: _STREAM_CONFIG.totalCapChars,
 };
+
+// Register the drain callback so sessionStore.registerStdinTab can flush
+// orphaned buffers without creating a circular import dependency.
+setOrphanDrainCallback(drainOrphanBuffer);
 
 // --- Shared pendingCommand completion helper (#27) ---
 // Both foreground and background handlers must clear pendingCommandMsgId when
@@ -151,106 +92,11 @@ export function completePendingCommand(tabId: string, opts: CompletePendingComma
   store.setSessionMeta(tabId, { pendingCommandMsgId: undefined });
 }
 
-// Interval fallback: flush any stuck buffers every 200ms
-let _flushIntervalId: ReturnType<typeof setInterval> | null = null;
-
-function _ensureFlushInterval() {
-  if (_flushIntervalId) return;
-  _flushIntervalId = setInterval(() => {
-    for (const [stdinId, buf] of _streamBuffers) {
-      if (buf.text || buf.thinking) {
-        _doFlush(stdinId, buf);
-      }
-    }
-    // Stop interval when no active buffers remain
-    if (_streamBuffers.size === 0 && _flushIntervalId) {
-      clearInterval(_flushIntervalId);
-      _flushIntervalId = null;
-    }
-  }, 200);
-}
-
-function _getBuffer(stdinId: string): _StreamBuffer {
-  let buf = _streamBuffers.get(stdinId);
-  if (!buf) {
-    buf = { text: '', thinking: '', raf: 0 };
-    _streamBuffers.set(stdinId, buf);
-  }
-  return buf;
-}
-
-/** Core flush logic — shared by rAF callback and interval fallback. */
-function _doFlush(stdinId: string, buf: _StreamBuffer) {
-  if (!buf.text && !buf.thinking) return;
-
-  const mappedId = useSessionStore.getState().getTabForStdin(stdinId);
-  const tabId = mappedId || useSessionStore.getState().selectedSessionId || undefined;
-  if (!mappedId && tabId) {
-    console.warn('[stream-flush] stdinId mapping missing, fallback to selectedSessionId:', stdinId, '→', tabId);
-    useSessionStore.getState().registerStdinTab(stdinId, tabId);
-  }
-  if (!tabId) {
-    // Instead of silent wipe, stash text in orphan queue so a late
-    // registerStdinTab() can drain it. Bounded and TTL'd.
-    _stashOrphan(stdinId, buf.text, buf.thinking);
-    buf.text = '';
-    buf.thinking = '';
-    return;
-  }
-
-  const store = useChatStore.getState();
-  if (buf.text) {
-    store.updatePartialMessage(tabId, buf.text);
-    buf.text = '';
-  }
-  if (buf.thinking) {
-    store.updatePartialThinking(tabId, buf.thinking);
-    buf.thinking = '';
-  }
-}
-
-// Register the drain callback so sessionStore.registerStdinTab can flush
-// orphaned buffers without creating a circular import dependency.
-setOrphanDrainCallback(drainOrphanBuffer);
-
-function _scheduleStreamFlush(stdinId: string) {
-  const buf = _getBuffer(stdinId);
-  // Start the interval fallback on first buffer activity
-  _ensureFlushInterval();
-  if (buf.raf) return;
-  buf.raf = requestAnimationFrame(() => {
-    buf.raf = 0;
-    _doFlush(stdinId, buf);
-  });
-}
-
 /** Flush any buffered streaming text immediately (call before clearPartial).
  *  If stdinId is provided, flush only that session's buffer.
  *  If omitted, flush ALL buffers (backward compat). */
 export function flushStreamBuffer(stdinId?: string) {
-  const ids = stdinId ? [stdinId] : Array.from(_streamBuffers.keys());
-
-  for (const id of ids) {
-    const buf = _streamBuffers.get(id);
-    if (!buf) continue;
-
-    if (buf.raf) {
-      cancelAnimationFrame(buf.raf);
-      buf.raf = 0;
-    }
-    _doFlush(id, buf);
-  }
-
-  // Clean up buffers and stop interval when all cleared
-  if (!stdinId) {
-    _streamBuffers.clear();
-  } else {
-    _streamBuffers.delete(stdinId);
-  }
-  if (_streamBuffers.size === 0 && _flushIntervalId) {
-    clearInterval(_flushIntervalId);
-    _flushIntervalId = null;
-  }
+  streamController.flush(stdinId);
 }
 
 // --- File tree auto-refresh on file-mutating tool completions ---
@@ -1140,19 +986,13 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
         if (evt.type === 'content_block_delta' && evt.delta?.type === 'text_delta') {
           const text = evt.delta.text || '';
           if (text && msgStdinId) {
-            // Buffer text and flush via rAF to avoid excessive re-renders
-            // TK-329: per-stdinId buffer prevents cross-session contamination
-            const buf = _getBuffer(msgStdinId);
-            buf.text += text;
-            _scheduleStreamFlush(msgStdinId);
+            streamController.appendText(msgStdinId, text);
             agentActions.updatePhase(agentId, 'writing');
           }
         } else if (evt.type === 'content_block_delta' && evt.delta?.type === 'thinking_delta') {
           const thinkingText = evt.delta.thinking || '';
           if (thinkingText && msgStdinId) {
-            const buf = _getBuffer(msgStdinId);
-            buf.thinking += thinkingText;
-            _scheduleStreamFlush(msgStdinId);
+            streamController.appendThinking(msgStdinId, thinkingText);
             agentActions.updatePhase(agentId, 'thinking');
           } else {
             setActivityStatus({ phase: 'thinking' });
@@ -2219,9 +2059,7 @@ export function useStreamProcessor(config: StreamProcessorConfig) {
         if (msg.type === 'content_block_delta') {
           const text = msg.delta?.text || '';
           if (text && msgStdinId) {
-            const buf = _getBuffer(msgStdinId);
-            buf.text += text;
-            _scheduleStreamFlush(msgStdinId);
+            streamController.appendText(msgStdinId, text);
           }
         }
         break;

--- a/src/stream/StreamController.ts
+++ b/src/stream/StreamController.ts
@@ -1,0 +1,305 @@
+/**
+ * StreamController · §4.3.1 单点源
+ *
+ * 统一持有流式状态的三处来源（rAF 缓冲 / orphan 队列 / 完成标记），
+ * 代替之前散落在 useStreamProcessor.ts 中的三地管理。
+ *
+ * 设计原则：
+ *   - 纯类，通过 DI 接 router + sink + scheduler（便于 jsdom 下 fake timer 测试）
+ *   - 所有 state 只能通过本类方法变更
+ *   - `completeStream` 原子：先 flush，再清理，再 emit `completed`；对同一 stdinId 幂等
+ *   - `clearPartial(stdinId)` 精准清理，不触其他会话
+ */
+
+export type StdinId = string;
+export type TabId = string;
+
+export interface StreamRouter {
+  getTabIdForStdin(stdinId: StdinId): TabId | null;
+}
+
+export interface StreamSink {
+  updatePartialText(tabId: TabId, text: string): void;
+  updatePartialThinking(tabId: TabId, text: string): void;
+}
+
+export interface Scheduler {
+  raf(cb: () => void): number;
+  cancelRaf(handle: number): void;
+  setInterval(cb: () => void, ms: number): ReturnType<typeof setInterval>;
+  clearInterval(handle: ReturnType<typeof setInterval>): void;
+  now(): number;
+}
+
+export const defaultScheduler: Scheduler = {
+  raf: (cb) => requestAnimationFrame(cb),
+  cancelRaf: (h) => cancelAnimationFrame(h),
+  setInterval: (cb, ms) => setInterval(cb, ms),
+  clearInterval: (h) => clearInterval(h),
+  now: () => Date.now(),
+};
+
+export interface StreamControllerConfig {
+  ttlMs: number;
+  perStdinCapChars: number;
+  totalCapChars: number;
+  intervalMs: number;
+}
+
+export const DEFAULT_CONFIG: StreamControllerConfig = {
+  ttlMs: 5_000,
+  perStdinCapChars: 1 * 1024 * 1024,
+  totalCapChars: 10 * 1024 * 1024,
+  intervalMs: 200,
+};
+
+export type StreamEvent =
+  | { type: 'partial-flushed'; stdinId: StdinId; tabId: TabId; textLen: number; thinkingLen: number }
+  | { type: 'orphan-stashed'; stdinId: StdinId; totalChars: number }
+  | { type: 'orphan-dropped'; stdinId: StdinId; reason: 'per-cap' | 'total-cap' | 'ttl' }
+  | { type: 'orphan-drained'; stdinId: StdinId; tabId: TabId }
+  | { type: 'completed'; stdinId: StdinId; tabId: TabId | null };
+
+type Listener = (evt: StreamEvent) => void;
+
+interface Buffer { text: string; thinking: string; raf: number }
+interface Orphan { text: string; thinking: string; expiresAt: number }
+
+export class StreamController {
+  private readonly buffers = new Map<StdinId, Buffer>();
+  private readonly orphans = new Map<StdinId, Orphan>();
+  private readonly completedOnce = new Set<StdinId>();
+  private intervalHandle: ReturnType<typeof setInterval> | null = null;
+  private readonly listeners = new Set<Listener>();
+
+  constructor(
+    private readonly router: StreamRouter,
+    private readonly sink: StreamSink,
+    private readonly scheduler: Scheduler = defaultScheduler,
+    private readonly config: StreamControllerConfig = DEFAULT_CONFIG,
+  ) {}
+
+  // --- Ingress ---
+
+  appendText(stdinId: StdinId, text: string): void {
+    if (!text) return;
+    if (this.completedOnce.has(stdinId)) return;
+    const buf = this.getOrCreateBuffer(stdinId);
+    buf.text += text;
+    this.schedule(stdinId, buf);
+  }
+
+  appendThinking(stdinId: StdinId, text: string): void {
+    if (!text) return;
+    if (this.completedOnce.has(stdinId)) return;
+    const buf = this.getOrCreateBuffer(stdinId);
+    buf.thinking += text;
+    this.schedule(stdinId, buf);
+  }
+
+  // --- Read-only peeks (for consumers that need in-flight buffer snapshots,
+  // e.g. TTS detector needs the fully accumulated text including not-yet-flushed
+  // delta, without breaking the controller's ownership of mutation).
+
+  peekBufferedText(stdinId: StdinId): string {
+    return this.buffers.get(stdinId)?.text ?? '';
+  }
+
+  peekBufferedThinking(stdinId: StdinId): string {
+    return this.buffers.get(stdinId)?.thinking ?? '';
+  }
+
+  // --- Flush ---
+
+  flush(stdinId?: StdinId): void {
+    const ids = stdinId !== undefined ? [stdinId] : Array.from(this.buffers.keys());
+    for (const id of ids) {
+      const buf = this.buffers.get(id);
+      if (!buf) continue;
+      if (buf.raf) { this.scheduler.cancelRaf(buf.raf); buf.raf = 0; }
+      this.doFlush(id, buf);
+      // Drop empty entries so flush() is idempotent w.r.t. buffer size.
+      if (!buf.text && !buf.thinking) this.buffers.delete(id);
+    }
+    if (this.buffers.size === 0) this.stopInterval();
+  }
+
+  // --- Lifecycle ---
+
+  /** Precisely drop buffered + partial state for one stdinId. */
+  clearPartial(stdinId: StdinId): void {
+    const buf = this.buffers.get(stdinId);
+    if (buf?.raf) this.scheduler.cancelRaf(buf.raf);
+    this.buffers.delete(stdinId);
+    if (this.buffers.size === 0) this.stopInterval();
+  }
+
+  /**
+   * Atomically finalize a stream: flush any pending buffer, clear state, and
+   * emit `completed` exactly once. Duplicate calls for the same stdinId are
+   * no-ops — guards against Rust-side dual-path process_exit races (§4.3.2).
+   */
+  completeStream(stdinId: StdinId): void {
+    if (this.completedOnce.has(stdinId)) return;
+    this.completedOnce.add(stdinId);
+    const buf = this.buffers.get(stdinId);
+    if (buf) {
+      if (buf.raf) { this.scheduler.cancelRaf(buf.raf); buf.raf = 0; }
+      this.doFlush(stdinId, buf);
+      this.buffers.delete(stdinId);
+    }
+    if (this.buffers.size === 0) this.stopInterval();
+    const tabId = this.router.getTabIdForStdin(stdinId);
+    this.emit({ type: 'completed', stdinId, tabId });
+  }
+
+  /** Test/cleanup hook: reset completion guard (e.g., stdinId reused). */
+  forgetCompletion(stdinId: StdinId): void {
+    this.completedOnce.delete(stdinId);
+  }
+
+  // --- Orphan queue ---
+
+  stashOrphan(stdinId: StdinId, text: string, thinking: string): void {
+    if (!text && !thinking) return;
+    this.expireOrphans();
+    const existing = this.orphans.get(stdinId);
+    const expiresAt = this.scheduler.now() + this.config.ttlMs;
+    const merged: Orphan = existing
+      ? { text: existing.text + text, thinking: existing.thinking + thinking, expiresAt }
+      : { text, thinking, expiresAt };
+    const mergedChars = merged.text.length + merged.thinking.length;
+    if (mergedChars > this.config.perStdinCapChars) {
+      this.orphans.delete(stdinId);
+      this.emit({ type: 'orphan-dropped', stdinId, reason: 'per-cap' });
+      return;
+    }
+    this.orphans.set(stdinId, merged);
+    while (this.orphanTotalChars() > this.config.totalCapChars) {
+      const oldest = this.orphans.keys().next().value;
+      if (!oldest) break;
+      this.orphans.delete(oldest);
+      this.emit({ type: 'orphan-dropped', stdinId: oldest, reason: 'total-cap' });
+    }
+    this.emit({ type: 'orphan-stashed', stdinId, totalChars: this.orphanTotalChars() });
+  }
+
+  drainOrphan(stdinId: StdinId, tabId: TabId): void {
+    this.expireOrphans();
+    const entry = this.orphans.get(stdinId);
+    if (!entry) return;
+    if (entry.text) this.sink.updatePartialText(tabId, entry.text);
+    if (entry.thinking) this.sink.updatePartialThinking(tabId, entry.thinking);
+    this.orphans.delete(stdinId);
+    this.emit({ type: 'orphan-drained', stdinId, tabId });
+  }
+
+  expireOrphans(): void {
+    const now = this.scheduler.now();
+    for (const [id, entry] of this.orphans.entries()) {
+      if (entry.expiresAt <= now) {
+        this.orphans.delete(id);
+        this.emit({ type: 'orphan-dropped', stdinId: id, reason: 'ttl' });
+      }
+    }
+  }
+
+  orphanTotalChars(): number {
+    let total = 0;
+    for (const e of this.orphans.values()) total += e.text.length + e.thinking.length;
+    return total;
+  }
+
+  // --- Subscriptions ---
+
+  on(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  // --- Internals ---
+
+  private getOrCreateBuffer(stdinId: StdinId): Buffer {
+    let buf = this.buffers.get(stdinId);
+    if (!buf) {
+      buf = { text: '', thinking: '', raf: 0 };
+      this.buffers.set(stdinId, buf);
+    }
+    return buf;
+  }
+
+  private schedule(stdinId: StdinId, buf: Buffer): void {
+    this.ensureInterval();
+    if (buf.raf) return;
+    buf.raf = this.scheduler.raf(() => {
+      buf.raf = 0;
+      this.doFlush(stdinId, buf);
+    });
+  }
+
+  private ensureInterval(): void {
+    if (this.intervalHandle) return;
+    this.intervalHandle = this.scheduler.setInterval(() => {
+      for (const [id, buf] of this.buffers) {
+        if (buf.text || buf.thinking) this.doFlush(id, buf);
+      }
+      if (this.buffers.size === 0) this.stopInterval();
+    }, this.config.intervalMs);
+  }
+
+  private stopInterval(): void {
+    if (!this.intervalHandle) return;
+    this.scheduler.clearInterval(this.intervalHandle);
+    this.intervalHandle = null;
+  }
+
+  private doFlush(stdinId: StdinId, buf: Buffer): void {
+    if (!buf.text && !buf.thinking) return;
+    const tabId = this.router.getTabIdForStdin(stdinId);
+    if (!tabId) {
+      this.stashOrphan(stdinId, buf.text, buf.thinking);
+      buf.text = '';
+      buf.thinking = '';
+      return;
+    }
+    const textLen = buf.text.length;
+    const thinkingLen = buf.thinking.length;
+    if (buf.text) {
+      this.sink.updatePartialText(tabId, buf.text);
+      buf.text = '';
+    }
+    if (buf.thinking) {
+      this.sink.updatePartialThinking(tabId, buf.thinking);
+      buf.thinking = '';
+    }
+    this.emit({ type: 'partial-flushed', stdinId, tabId, textLen, thinkingLen });
+  }
+
+  private emit(evt: StreamEvent): void {
+    for (const l of this.listeners) {
+      try { l(evt); } catch (e) { console.error('[StreamController] listener threw', e); }
+    }
+  }
+
+  // --- Test seams ---
+
+  readonly __testing = {
+    getBuffer: (stdinId: StdinId) => this.buffers.get(stdinId),
+    getOrphan: (stdinId: StdinId) => this.orphans.get(stdinId),
+    hasBuffer: (stdinId: StdinId) => this.buffers.has(stdinId),
+    hasOrphan: (stdinId: StdinId) => this.orphans.has(stdinId),
+    buffersSize: () => this.buffers.size,
+    orphansSize: () => this.orphans.size,
+    orphanTotalChars: () => this.orphanTotalChars(),
+    isCompleted: (stdinId: StdinId) => this.completedOnce.has(stdinId),
+    forceExpire: () => this.expireOrphans(),
+    clear: () => {
+      for (const b of this.buffers.values()) if (b.raf) this.scheduler.cancelRaf(b.raf);
+      this.buffers.clear();
+      this.orphans.clear();
+      this.completedOnce.clear();
+      this.stopInterval();
+    },
+    config: this.config,
+  };
+}

--- a/src/stream/__tests__/StreamController.test.ts
+++ b/src/stream/__tests__/StreamController.test.ts
@@ -1,0 +1,230 @@
+/**
+ * StreamController regression guard — roadmap §4.5.1.
+ *
+ * Covers the 10 Vitest unit contracts the roadmap calls out for §4.3.1.
+ * All cases inject a MockScheduler so the rAF / interval coroutines are
+ * deterministic under jsdom without racing the real event loop.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  StreamController,
+  type StreamRouter,
+  type StreamSink,
+  type Scheduler,
+  type StreamEvent,
+  DEFAULT_CONFIG,
+} from '../StreamController';
+
+class MockScheduler implements Scheduler {
+  time = 0;
+  private rafQueue: Array<{ id: number; cb: () => void }> = [];
+  private intervals: Array<{ id: number; cb: () => void; ms: number; last: number }> = [];
+  private nextId = 1;
+
+  raf(cb: () => void): number {
+    const id = this.nextId++;
+    this.rafQueue.push({ id, cb });
+    return id;
+  }
+  cancelRaf(id: number): void {
+    this.rafQueue = this.rafQueue.filter((e) => e.id !== id);
+  }
+  setInterval(cb: () => void, ms: number): ReturnType<typeof setInterval> {
+    const id = this.nextId++;
+    this.intervals.push({ id, cb, ms, last: this.time });
+    return id as unknown as ReturnType<typeof setInterval>;
+  }
+  clearInterval(h: ReturnType<typeof setInterval>): void {
+    this.intervals = this.intervals.filter((e) => e.id !== (h as unknown as number));
+  }
+  now(): number {
+    return this.time;
+  }
+
+  /** Drain all pending rAF callbacks (FIFO). */
+  flushRaf(): void {
+    const pending = this.rafQueue;
+    this.rafQueue = [];
+    for (const e of pending) e.cb();
+  }
+  /** Advance time and fire any intervals whose deadline passed. */
+  advance(ms: number): void {
+    this.time += ms;
+    for (const iv of this.intervals) {
+      while (this.time - iv.last >= iv.ms) {
+        iv.last += iv.ms;
+        iv.cb();
+      }
+    }
+  }
+  /** Number of rAF callbacks still pending (for asserting raF-starvation path). */
+  pendingRaf(): number {
+    return this.rafQueue.length;
+  }
+}
+
+function makeHarness(routes: Record<string, string | null> = {}) {
+  const router: StreamRouter = {
+    getTabIdForStdin: (stdinId) => (stdinId in routes ? routes[stdinId] : null),
+  };
+  const textCalls: Array<[string, string]> = [];
+  const thinkingCalls: Array<[string, string]> = [];
+  const sink: StreamSink = {
+    updatePartialText: (tabId, text) => textCalls.push([tabId, text]),
+    updatePartialThinking: (tabId, text) => thinkingCalls.push([tabId, text]),
+  };
+  const scheduler = new MockScheduler();
+  const ctrl = new StreamController(router, sink, scheduler);
+  const events: StreamEvent[] = [];
+  ctrl.on((e) => events.push(e));
+  return { ctrl, scheduler, textCalls, thinkingCalls, events };
+}
+
+describe('StreamController · §4.3.1', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('clearPartial', () => {
+    it('clearPartial_with_stdinId_only_clears_target', () => {
+      const { ctrl, scheduler } = makeHarness({ s1: 't1' });
+      ctrl.appendText('s1', 'hello');
+      expect(ctrl.__testing.hasBuffer('s1')).toBe(true);
+      ctrl.clearPartial('s1');
+      expect(ctrl.__testing.hasBuffer('s1')).toBe(false);
+      // No residual raF should fire into sink after clear.
+      scheduler.flushRaf();
+    });
+
+    it('clearPartial_does_not_touch_other_sessions', () => {
+      const { ctrl } = makeHarness({ s1: 't1', s2: 't2' });
+      ctrl.appendText('s1', 'alpha');
+      ctrl.appendText('s2', 'beta');
+      ctrl.clearPartial('s1');
+      expect(ctrl.__testing.hasBuffer('s1')).toBe(false);
+      expect(ctrl.__testing.hasBuffer('s2')).toBe(true);
+      expect(ctrl.__testing.getBuffer('s2')?.text).toBe('beta');
+    });
+  });
+
+  describe('completeStream', () => {
+    it('completeStream_flushes_before_clear', () => {
+      const { ctrl, textCalls, thinkingCalls } = makeHarness({ s1: 't1' });
+      ctrl.appendText('s1', 'trailing text');
+      ctrl.appendThinking('s1', 'trailing thinking');
+      // rAF has not been drained; buffer holds content.
+      expect(ctrl.__testing.getBuffer('s1')?.text).toBe('trailing text');
+      ctrl.completeStream('s1');
+      // Sink received the flush.
+      expect(textCalls).toEqual([['t1', 'trailing text']]);
+      expect(thinkingCalls).toEqual([['t1', 'trailing thinking']]);
+      // Buffer is gone.
+      expect(ctrl.__testing.hasBuffer('s1')).toBe(false);
+    });
+
+    it('completeStream_is_atomic_under_raF_delay', () => {
+      // Simulate the background-tab scenario: rAF never fires, interval never
+      // fires, yet completeStream must still flush the last chunk deterministically.
+      const { ctrl, scheduler, textCalls } = makeHarness({ s1: 't1' });
+      ctrl.appendText('s1', 'last-bytes');
+      expect(scheduler.pendingRaf()).toBe(1);
+      // Do NOT drain rAF / advance interval.
+      ctrl.completeStream('s1');
+      expect(textCalls).toEqual([['t1', 'last-bytes']]);
+      // After complete, the pending rAF is cancelled (no double-flush).
+      scheduler.flushRaf();
+      expect(textCalls.length).toBe(1);
+    });
+
+    it('completeStream_emits_exactly_once_under_duplicate_process_exit', () => {
+      const { ctrl, events } = makeHarness({ s1: 't1' });
+      ctrl.appendText('s1', 'hi');
+      ctrl.completeStream('s1');
+      ctrl.completeStream('s1'); // duplicate from second Rust path
+      ctrl.completeStream('s1'); // extra just to be safe
+      const completed = events.filter((e) => e.type === 'completed');
+      expect(completed).toHaveLength(1);
+    });
+
+    it('completeStream_ignores_appends_after_completion', () => {
+      // Late stragglers after process_exit must not reopen a tab stream.
+      const { ctrl, textCalls } = makeHarness({ s1: 't1' });
+      ctrl.completeStream('s1');
+      ctrl.appendText('s1', 'too late');
+      expect(ctrl.__testing.hasBuffer('s1')).toBe(false);
+      expect(textCalls).toEqual([]);
+    });
+  });
+
+  describe('orphan queue', () => {
+    it('orphan_queue_expires_after_5s', () => {
+      const { ctrl, scheduler, events } = makeHarness();
+      ctrl.stashOrphan('s1', 'hello', '');
+      expect(ctrl.__testing.hasOrphan('s1')).toBe(true);
+      scheduler.time += DEFAULT_CONFIG.ttlMs + 1;
+      ctrl.expireOrphans();
+      expect(ctrl.__testing.hasOrphan('s1')).toBe(false);
+      const dropped = events.find(
+        (e) => e.type === 'orphan-dropped' && e.reason === 'ttl',
+      );
+      expect(dropped).toBeTruthy();
+    });
+
+    it('orphan_queue_delivers_when_session_binds', () => {
+      const { ctrl, textCalls, thinkingCalls, events } = makeHarness();
+      ctrl.stashOrphan('s1', 'early tokens ', 'early thinking ');
+      ctrl.drainOrphan('s1', 'tab-001');
+      expect(textCalls).toEqual([['tab-001', 'early tokens ']]);
+      expect(thinkingCalls).toEqual([['tab-001', 'early thinking ']]);
+      expect(ctrl.__testing.hasOrphan('s1')).toBe(false);
+      expect(events.some((e) => e.type === 'orphan-drained')).toBe(true);
+    });
+
+    it('orphan_queue_no_infinite_growth', () => {
+      const { ctrl } = makeHarness();
+      const chunk = 'y'.repeat(128 * 1024);
+      const n = Math.ceil(DEFAULT_CONFIG.totalCapChars / chunk.length) + 10;
+      for (let i = 0; i < n; i++) ctrl.stashOrphan(`s_${i}`, chunk, '');
+      expect(ctrl.__testing.orphanTotalChars()).toBeLessThanOrEqual(
+        DEFAULT_CONFIG.totalCapChars,
+      );
+    });
+
+    it('orphan_queue_enforces_per_stdin_cap', () => {
+      const { ctrl } = makeHarness();
+      const oversize = 'x'.repeat(DEFAULT_CONFIG.perStdinCapChars + 1);
+      ctrl.stashOrphan('s_big', oversize, '');
+      expect(ctrl.__testing.hasOrphan('s_big')).toBe(false);
+    });
+
+    it('orphan_routes_to_queue_when_router_returns_null', () => {
+      // doFlush with no tabId → stash into orphan queue, buffer cleared.
+      const { ctrl, scheduler } = makeHarness();
+      ctrl.appendText('unknown', 'flow into orphan');
+      scheduler.flushRaf();
+      expect(ctrl.__testing.hasOrphan('unknown')).toBe(true);
+      expect(ctrl.__testing.getOrphan('unknown')?.text).toBe('flow into orphan');
+    });
+  });
+
+  describe('scheduling', () => {
+    it('rAF_coalesces_rapid_appends_into_single_flush', () => {
+      const { ctrl, scheduler, textCalls } = makeHarness({ s1: 't1' });
+      ctrl.appendText('s1', 'a');
+      ctrl.appendText('s1', 'b');
+      ctrl.appendText('s1', 'c');
+      expect(scheduler.pendingRaf()).toBe(1);
+      scheduler.flushRaf();
+      expect(textCalls).toEqual([['t1', 'abc']]);
+    });
+
+    it('interval_fallback_flushes_when_rAF_starved', () => {
+      // rAF never drained, but interval tick arrives → buffer still flushes.
+      const { ctrl, scheduler, textCalls } = makeHarness({ s1: 't1' });
+      ctrl.appendText('s1', 'background');
+      expect(textCalls.length).toBe(0);
+      scheduler.advance(DEFAULT_CONFIG.intervalMs);
+      expect(textCalls).toEqual([['t1', 'background']]);
+    });
+  });
+});

--- a/src/stream/instance.ts
+++ b/src/stream/instance.ts
@@ -1,0 +1,36 @@
+/**
+ * Singleton StreamController wired to TOKENICODE's live stores.
+ *
+ * The controller is the single owner of streaming state (rAF buffer, orphan
+ * queue, completion guard). This module binds it to sessionStore (for
+ * stdinId → tabId routing) and chatStore (as partial-text / partial-thinking
+ * sink), using default rAF + setInterval scheduling.
+ *
+ * §4.6 note: unlike the legacy useStreamProcessor path, this router does NOT
+ * fall back to `selectedSessionId` when the stdin→tab mapping is missing.
+ * Unmapped flushes are stashed in the orphan queue and drained on bind.
+ */
+import { useChatStore } from '../stores/chatStore';
+import { useSessionStore } from '../stores/sessionStore';
+import {
+  StreamController,
+  DEFAULT_CONFIG,
+  type StreamRouter,
+  type StreamSink,
+} from './StreamController';
+
+const router: StreamRouter = {
+  getTabIdForStdin: (stdinId) =>
+    useSessionStore.getState().getTabForStdin(stdinId) ?? null,
+};
+
+const sink: StreamSink = {
+  updatePartialText: (tabId, text) =>
+    useChatStore.getState().updatePartialMessage(tabId, text),
+  updatePartialThinking: (tabId, text) =>
+    useChatStore.getState().updatePartialThinking(tabId, text),
+};
+
+export const streamController = new StreamController(router, sink);
+
+export { DEFAULT_CONFIG };


### PR DESCRIPTION
## Summary
- Mirror of Her PR-A/PR-B (§4.3.1 StreamController 单点源)
- Introduces `StreamController` class that owns rAF buffer + orphan queue + completion guard behind Router/Sink/Scheduler DI
- Converts `useStreamProcessor.ts` to a thin adapter that delegates via `src/stream/instance.ts`
- **§4.6**: drops the orphan→`selectedSessionId` fallback — unmapped flushes now go to the orphan queue and drain on bind
- 13 unit tests green (MockScheduler-driven, deterministic under jsdom)

## Files
- `src/stream/StreamController.ts` (new, ~310 lines)
- `src/stream/instance.ts` (new) — binds sessionStore (`getTabForStdin`) + chatStore
- `src/stream/__tests__/StreamController.test.ts` (new, 13 tests)
- `src/hooks/useStreamProcessor.ts` — removed inline state block, 3 content_block_delta write sites delegate to `streamController.appendText`/`appendThinking`

## Test plan
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run src/stream` — 13/13 passing
- [ ] Manual smoke: streaming message renders partial text + thinking per tab
- [ ] Manual: mid-stream stdinId→tab binding drains orphan queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)