### PR TITLE
[codex] Prefer local system font stack

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -345,7 +345,7 @@ html, body, #root {
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont,
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'PingFang SC',
     'Segoe UI', 'Roboto', 'Helvetica Neue',
     Arial, sans-serif;
   background-color: var(--color-bg-primary);


### PR DESCRIPTION
## Summary
- remove Inter as the preferred app font
- use local system fonts first, including SF Pro Text and PingFang SC

## Why
This prevents the desktop app from depending on web font availability if a future build or shell reintroduces an Inter web-font source. It also keeps the UI stable for intranet-only users.

## Validation
- pnpm exec tsc --noEmit
- confirmed no fonts.googleapis.com / fonts.gstatic.com / DM Sans references exist in index.html or src