### PR TITLE
fix: LRU 驱逐保护未投递的 partialText/partialThinking

### DIFF
--- a/src/stores/__tests__/chatStoreRestore.test.ts
+++ b/src/stores/__tests__/chatStoreRestore.test.ts
@@ -169,6 +169,60 @@ describe('chatStore · B11 — stale-running demotion on restoreFromCache', () =
     expect(useChatStore.getState().getTab('old-1')).toBeUndefined();
   });
 
+  it('idle tab with undelivered partialText is protected from LRU eviction', () => {
+    const store = useChatStore.getState();
+    const ids = ['partial-keep', 'old-1', 'old-2', 'old-3', 'old-4', 'old-5', 'old-6', 'old-7'];
+    for (const id of ids) {
+      store.ensureTab(id);
+      store.addMessage(id, msg(`m-${id}`));
+    }
+    useChatStore.setState((state) => {
+      const tabs = new Map(state.tabs);
+      ids.forEach((id, idx) => {
+        const tab = tabs.get(id);
+        if (!tab) return;
+        tabs.set(id, {
+          ...tab,
+          lastAccessedAt: idx + 1,
+          ...(id === 'partial-keep' ? { partialText: 'streamed but not finalized' } : {}),
+        });
+      });
+      return { tabs, sessionCache: tabs };
+    });
+
+    store.ensureTab('incoming');
+
+    expect(useChatStore.getState().getTab('partial-keep')).toBeDefined();
+    expect(useChatStore.getState().getTab('old-1')).toBeUndefined();
+  });
+
+  it('idle tab with undelivered partialThinking is protected from LRU eviction', () => {
+    const store = useChatStore.getState();
+    const ids = ['thinking-keep', 'old-1', 'old-2', 'old-3', 'old-4', 'old-5', 'old-6', 'old-7'];
+    for (const id of ids) {
+      store.ensureTab(id);
+      store.addMessage(id, msg(`m-${id}`));
+    }
+    useChatStore.setState((state) => {
+      const tabs = new Map(state.tabs);
+      ids.forEach((id, idx) => {
+        const tab = tabs.get(id);
+        if (!tab) return;
+        tabs.set(id, {
+          ...tab,
+          lastAccessedAt: idx + 1,
+          ...(id === 'thinking-keep' ? { partialThinking: 'reasoning in flight' } : {}),
+        });
+      });
+      return { tabs, sessionCache: tabs };
+    });
+
+    store.ensureTab('incoming');
+
+    expect(useChatStore.getState().getTab('thinking-keep')).toBeDefined();
+    expect(useChatStore.getState().getTab('old-1')).toBeUndefined();
+  });
+
   it('attachment-only tabs restore instead of being treated as empty cache misses', () => {
     const store = useChatStore.getState();
     store.ensureTab('attachments-only');

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -765,6 +765,9 @@ export const useChatStore = create<ChatState>()((set, get) => ({
           if (entry.inputDraft.trim().length > 0) return false;
           if (entry.pendingAttachments.length > 0) return false;
           if (entry.pendingUserMessages.length > 0) return false;
+          // Undelivered stream content not yet finalized into messages —
+          // evicting here would silently drop it (#86).
+          if (entry.partialText || entry.partialThinking) return false;
           return true;
         })
         .sort(([, a], [, b]) => a.lastAccessedAt - b.lastAccessedAt); // oldest first


### PR DESCRIPTION
## Summary

#86 的现代化 port：main 的 LRU 驱逐 filter 已演进出 streaming / isSessionBusy（含 reconnecting）/ stdin 绑定 / 草稿 / 待发附件等保护，但 **有未落盘流式内容（`partialText` / `partialThinking`）的 tab 仍会被驱逐**——用户已经看到的流式文本会静默丢失。本 PR 在 filter 中补上这最后一条保护。

原始发现归功于 @suyuan2022（#86）；该 PR 基于 4 月的旧驱逐结构已无法直接合并，按当前架构以 TDD 重新实现。

## Test plan
- [x] RED：chatStoreRestore 新增 2 个用例（partialText / partialThinking 各一），改动前确认失败
- [x] GREEN：filter 增加保护后通过
- [x] 全量 vitest 282/282、tsc 干净