### PR TITLE
fix(chat): 路径胶囊点击定位两层修复——后缀兜底 + 树快照竞态

### DIFF
--- a/src/stores/__tests__/fileReveal.test.ts
+++ b/src/stores/__tests__/fileReveal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { classifyPathToken, computeRevealExpansions, findNodeByPath, normalizePath, reconcilePathToRoot, resolvePathToken } from '../fileReveal';
+import { classifyPathToken, computeRevealExpansions, findNodeByPath, findNodeBySuffix, normalizePath, reconcilePathToRoot, resolvePathToken } from '../fileReveal';
 import type { FileNode } from '../../lib/tauri-bridge';
 
 describe('normalizePath', () => {
@@ -91,6 +91,74 @@ describe('findNodeByPath（按绝对路径在树里找节点）', () => {
   });
   it('找不到返回 null', () => {
     expect(findNodeByPath(tree, '/root/不存在/x')).toBe(null);
+  });
+});
+
+// AI 在聊天里给的路径，极少是「从工作区根算起的完整相对路径」，更多是裸文件名
+// （brief_2026-06-06.md）或半截相对路径。这类 token 拼出来的绝对路径在树里不存在，
+// findNodeByPath 精确匹配会失败 → 这是「点了胶囊不展开不高亮」的主因。
+// findNodeBySuffix 兜底：按基名 + 共享结尾段数，在已加载的树里找回真实节点。
+describe('findNodeBySuffix（裸文件名 / 半截路径按后缀在树里兜底定位）', () => {
+  const tree: FileNode[] = [
+    { name: '00_专注区', path: '/root/00_专注区', is_dir: true, children: [
+      { name: 'brief_2026-06-06.md', path: '/root/00_专注区/brief_2026-06-06.md', is_dir: false, children: null },
+      { name: '参考资料', path: '/root/00_专注区/参考资料', is_dir: true, children: [] },
+    ] },
+    { name: '06_DEV', path: '/root/06_DEV', is_dir: true, children: [
+      { name: 'HANDOFF.md', path: '/root/06_DEV/HANDOFF.md', is_dir: false, children: null },
+      { name: '_本周.md', path: '/root/06_DEV/_本周.md', is_dir: false, children: null },
+    ] },
+    { name: '01_Her', path: '/root/01_Her', is_dir: true, children: [
+      { name: '_本周.md', path: '/root/01_Her/_本周.md', is_dir: false, children: null },
+    ] },
+  ];
+
+  it('裸文件名命中子文件夹里的真实节点', () => {
+    expect(findNodeBySuffix(tree, '/root/brief_2026-06-06.md')?.path)
+      .toBe('/root/00_专注区/brief_2026-06-06.md');
+  });
+
+  it('半截相对路径：按共享结尾段数命中对的那个同名文件', () => {
+    // 两个 _本周.md：给了 06_DEV/_本周.md → 应命中 06_DEV 下的，而不是 01_Her 下的
+    expect(findNodeBySuffix(tree, '/root/06_DEV/_本周.md')?.path)
+      .toBe('/root/06_DEV/_本周.md');
+  });
+
+  it('同名并列、信息不足时取路径最短（更靠近根，结果稳定）', () => {
+    // 只给裸 _本周.md，无从区分 → 两者结尾段数相同，取更短路径；这里长度相同则取先遇到的
+    const hit = findNodeBySuffix(tree, '/root/_本周.md');
+    expect(hit?.name).toBe('_本周.md');
+  });
+
+  it('文件夹也能按基名命中', () => {
+    expect(findNodeBySuffix(tree, '/root/参考资料')?.path)
+      .toBe('/root/00_专注区/参考资料');
+    expect(findNodeBySuffix(tree, '/root/参考资料')?.is_dir).toBe(true);
+  });
+
+  it('树里没有同名节点 → null', () => {
+    expect(findNodeBySuffix(tree, '/root/不存在.md')).toBe(null);
+  });
+});
+
+// 复现并锁死本次 bug：聊天里点「裸文件名」胶囊，过去按「根 + 文件名」精确匹配，
+// 而文件其实在子文件夹里 → 匹配不到 → 不展开不高亮。修复后应能定位到真实节点、
+// 算出要展开的祖先文件夹。
+describe('裸文件名定位回归（revealPath 纯逻辑链路）', () => {
+  const root = '/root';
+  const tree: FileNode[] = [
+    { name: '00_专注区', path: '/root/00_专注区', is_dir: true, children: [
+      { name: 'brief_2026-06-06.md', path: '/root/00_专注区/brief_2026-06-06.md', is_dir: false, children: null },
+    ] },
+  ];
+
+  it('裸文件名：精确匹配失败（旧 bug），后缀兜底命中并算出要展开 00_专注区', () => {
+    const resolved = resolvePathToken('brief_2026-06-06.md', root); // → /root/brief_2026-06-06.md
+    expect(findNodeByPath(tree, resolved)).toBe(null);              // 旧路径：精确匹配不到 = bug 现场
+    const node = findNodeByPath(tree, resolved) ?? findNodeBySuffix(tree, resolved);
+    expect(node?.path).toBe('/root/00_专注区/brief_2026-06-06.md'); // 新兜底：定位到真实节点
+    expect(computeRevealExpansions(node!.path, root, node!.is_dir))
+      .toEqual(['/root/00_专注区']);                                // 真实节点 → 正确的展开列表
   });
 });
 

--- a/src/stores/__tests__/fileStoreReveal.test.ts
+++ b/src/stores/__tests__/fileStoreReveal.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { FileNode } from '../../lib/tauri-bridge';
+
+// 只 mock 桥接层：readFileTree 可控；fileReveal 纯函数用真实现（链路更接近实跑）
+vi.mock('../../lib/tauri-bridge', () => ({
+  bridge: {
+    readFileTree: vi.fn(),
+  },
+}));
+
+import { bridge } from '../../lib/tauri-bridge';
+import { useFileStore } from '../fileStore';
+
+const ROOT = '/root/2026工作间';
+const DEEP_DIR = `${ROOT}/03_教学/08_演讲/618 43 talks`;
+const NEW_FILE = `${DEEP_DIR}/00_总控PRD.md`;
+
+/** 不含新文件的树快照（loadTree 时刻的旧状态） */
+const staleTree = (): FileNode[] => [
+  { name: '03_教学', path: `${ROOT}/03_教学`, is_dir: true, children: [
+    { name: '08_演讲', path: `${ROOT}/03_教学/08_演讲`, is_dir: true, children: [
+      { name: '618 43 talks', path: DEEP_DIR, is_dir: true, children: [
+        { name: '01_叙事逻辑.md', path: `${DEEP_DIR}/01_叙事逻辑.md`, is_dir: false, children: null },
+      ] },
+    ] },
+  ] },
+];
+
+/** 磁盘上的最新树：AI 刚写出的 00_总控PRD.md 已存在 */
+const freshTree = (): FileNode[] => {
+  const t = staleTree();
+  t[0].children![0].children![0].children!.push(
+    { name: '00_总控PRD.md', path: NEW_FILE, is_dir: false, children: null },
+  );
+  return t;
+};
+
+beforeEach(() => {
+  vi.mocked(bridge.readFileTree).mockReset();
+  useFileStore.setState({
+    rootPath: ROOT,
+    tree: staleTree(),
+    expandedFolders: new Set<string>(),
+    revealTarget: null,
+  });
+});
+
+// 复现 2026-06-10 现场：流式对话中 AI 刚交付 00_总控PRD.md，胶囊即时出现，
+// 但树还是旧快照（watcher/工具完成的刷新是异步追赶的）→ 点击必须自己把树对齐。
+describe('revealPath：树快照落后于磁盘时主动刷新再定位', () => {
+  it('新文件不在树里 → 自动 refreshTree → 兜底命中真实节点并展开三层祖先', async () => {
+    vi.mocked(bridge.readFileTree).mockResolvedValue(freshTree());
+
+    // 胶囊给的是裸文件名，resolve 后挂在根下（实际文件在四层深处）
+    await useFileStore.getState().revealPath(`${ROOT}/00_总控PRD.md`);
+
+    expect(bridge.readFileTree).toHaveBeenCalledTimes(1); // 发生了主动刷新
+    const s = useFileStore.getState();
+    expect(s.revealTarget).toBe(NEW_FILE);
+    expect(s.expandedFolders.has(`${ROOT}/03_教学`)).toBe(true);
+    expect(s.expandedFolders.has(`${ROOT}/03_教学/08_演讲`)).toBe(true);
+    expect(s.expandedFolders.has(DEEP_DIR)).toBe(true);
+  });
+
+  it('文件已在树里 → 不触发多余的刷新', async () => {
+    await useFileStore.getState().revealPath(`${DEEP_DIR}/01_叙事逻辑.md`);
+
+    expect(bridge.readFileTree).not.toHaveBeenCalled();
+    expect(useFileStore.getState().revealTarget).toBe(`${DEEP_DIR}/01_叙事逻辑.md`);
+  });
+
+  it('刷新后磁盘上也没有 → 维持原回退行为（revealTarget 用 reconciled 值，不误定位）', async () => {
+    vi.mocked(bridge.readFileTree).mockResolvedValue(staleTree());
+
+    await useFileStore.getState().revealPath(`${ROOT}/不存在.md`);
+
+    expect(bridge.readFileTree).toHaveBeenCalledTimes(1);
+    expect(useFileStore.getState().revealTarget).toBe(`${ROOT}/不存在.md`);
+  });
+});

--- a/src/stores/fileReveal.ts
+++ b/src/stores/fileReveal.ts
@@ -107,6 +107,60 @@ export function findNodeByPath(tree: FileNode[], path: string): FileNode | null 
 }
 
 /**
+ * 兜底：按「路径后缀」在已加载的树里找最匹配的节点。
+ *
+ * findNodeByPath 要求绝对路径精确相等，但 AI 在聊天里给的路径极少是「从工作区
+ * 根算起的完整相对路径」——更多是裸文件名（brief_2026-06-06.md）或半截相对路径。
+ * 这类 token 经 resolvePathToken 拼成的绝对路径（当成就在根下）在树里根本不存在，
+ * 精确匹配必然 null → 点了胶囊不展开不高亮。这是该功能「过半点击没反应」的主因。
+ *
+ * 策略：取 targetPath 的基名（最后一段），收集树里所有同名节点；
+ * - 唯一 → 直接用；
+ * - 多个同名 → 按「与 targetPath 共享的结尾路径段数」打分取最高（让
+ *   06_DEV/_本周.md 命中 06_DEV 下那个而非别处同名文件），并列再取路径最短者
+ *   （更靠近根，结果稳定可预测）。
+ * 没有同名节点 → null（调用方维持原行为，不误定位）。
+ *
+ * 纯函数：遍历入参树、不改动它，便于在 node 环境直接单测。
+ */
+export function findNodeBySuffix(tree: FileNode[], targetPath: string): FileNode | null {
+  const targetSegs = normalizePath(targetPath).split('/').filter(Boolean);
+  const baseName = targetSegs[targetSegs.length - 1];
+  if (!baseName) return null;
+
+  const candidates: FileNode[] = [];
+  const walk = (nodes: FileNode[]) => {
+    for (const n of nodes) {
+      const segs = normalizePath(n.path).split('/').filter(Boolean);
+      if (segs[segs.length - 1] === baseName) candidates.push(n);
+      if (n.children) walk(n.children);
+    }
+  };
+  walk(tree);
+
+  if (candidates.length === 0) return null;
+  if (candidates.length === 1) return candidates[0];
+
+  // 与 target 从末尾往前共享多少段，段数越多越可能是用户指的那个
+  const sharedTail = (p: string): number => {
+    const segs = normalizePath(p).split('/').filter(Boolean);
+    let i = 0;
+    while (
+      i < segs.length &&
+      i < targetSegs.length &&
+      segs[segs.length - 1 - i] === targetSegs[targetSegs.length - 1 - i]
+    ) i++;
+    return i;
+  };
+
+  return candidates.slice().sort((a, b) => {
+    const byTail = sharedTail(b.path) - sharedTail(a.path);
+    if (byTail !== 0) return byTail;
+    return normalizePath(a.path).length - normalizePath(b.path).length;
+  })[0];
+}
+
+/**
  * 容错：把前缀可能不准的绝对路径«对齐»回真实 rootPath 下。
  *
  * AI 在聊天里给的绝对全路径，前缀常和真实文件系统不一致——iCloud 的

--- a/src/stores/fileStore.ts
+++ b/src/stores/fileStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { bridge, FileNode, RecentProject } from '../lib/tauri-bridge';
-import { computeRevealExpansions, findNodeByPath, reconcilePathToRoot } from './fileReveal';
+import { computeRevealExpansions, findNodeByPath, findNodeBySuffix, reconcilePathToRoot } from './fileReveal';
 
 export type FileChangeKind = 'created' | 'modified' | 'removed';
 export type PreviewMode = 'preview' | 'source' | 'edit';
@@ -72,7 +72,7 @@ interface FileState {
   // 展开/折叠单个文件夹
   toggleFolder: (path: string) => void;
   // 定位到某路径：展开其所有父目录（文件夹则连自身）并高亮
-  revealPath: (path: string) => void;
+  revealPath: (path: string) => Promise<void>;
 }
 
 export const useFileStore = create<FileState>()((set, get) => ({
@@ -350,16 +350,33 @@ export const useFileStore = create<FileState>()((set, get) => ({
     set({ expandedFolders: next });
   },
 
-  revealPath: (path: string) => {
-    const { tree, rootPath, expandedFolders } = get();
+  revealPath: async (path: string) => {
+    const { rootPath } = get();
     // 容错：AI 给的绝对全路径前缀可能和真实文件系统不一致（iCloud 的
     // com~apple~CloudDocs 常被写成 com-apple-CloudDocs 或整段缺失）→ 按工作区名对齐回真实 rootPath。
-    const target = reconcilePathToRoot(path, rootPath);
-    // 判断目标是文件还是文件夹：先在已加载的树里查，查不到回退到「末尾斜杠」
-    const node = findNodeByPath(tree, target);
+    const reconciled = reconcilePathToRoot(path, rootPath);
+    // 先精确匹配；匹配不到（裸文件名 / 半截相对路径——AI 给的多是这种）再按基名/后缀
+    // 在已加载的树里兜底找回真实节点。这是修「过半点击不展开不高亮」的关键：
+    // 展开 + 高亮都必须用「树里真实节点的 path」，而不是拼出来、很可能对不上的 reconciled。
+    const locate = () => {
+      const tree = get().tree;
+      return findNodeByPath(tree, reconciled) ?? findNodeBySuffix(tree, reconciled);
+    };
+    let node = locate();
+    // 时序竞态兜底：流式对话里 AI 刚写出的文件，大概率还没进树快照——
+    // watcher / 工具完成触发的 refreshTree 是异步追赶的（大工作区全量扫描要数秒），
+    // 而胶囊随流式文本即时出现，点击必然跑在刷新前面。
+    // → 树里找不到时主动刷一次再定位，把「被动等树追上」变成「点击时对齐」。
+    if (!node) {
+      await get().refreshTree();
+      node = locate();
+    }
+    // 用真实节点的 path 原值（不再 normalize）：TreeNode 的高亮判断是
+    // revealTarget === node.path 原值精确相等，包一层规范化反而可能对不上。
+    const target = node ? node.path : reconciled;
     const isDir = node ? node.is_dir : /\/$/.test(path);
     const toExpand = computeRevealExpansions(target, rootPath, isDir);
-    const next = new Set(expandedFolders);
+    const next = new Set(get().expandedFolders);
     for (const p of toExpand) next.add(p);
     set({ expandedFolders: next, revealTarget: target });
   },


### PR DESCRIPTION
## 问题

聊天里 AI 交付文档的路径胶囊，点击后右侧文件树不展开、不高亮。两个独立原因叠加：

1. **路径对不上**：AI 在文本里给的多是裸文件名（如 `00_总控PRD.md`）或半截相对路径，按「工作区根 + token」拼出的绝对路径在树里不存在，精确匹配必败。
2. **树快照落后于磁盘**：流式对话中刚写出的文件还没进前端树快照——watcher / 工具完成触发的 refreshTree 是 300ms 防抖 + 异步全量扫描（大工作区要数秒），而胶囊随流式文本即时出现，点击永远跑在刷新前面。越是「刚交付的文档」越点不动。

## 修复

1. `findNodeBySuffix`（fileReveal.ts）：按基名收集树中同名节点；多个同名按「与目标共享的结尾路径段数」打分取最高，并列取路径最短——`06_DEV/_本周.md` 能命中对的那个，不误定位；树里没有同名节点则返回 null，维持原回退行为。
2. `revealPath`（fileStore.ts）：精确匹配 + 后缀兜底都失败时，主动 `refreshTree()` 一次再重试定位——把「被动等树追上」变成「点击时对齐」，消灭时序竞态。

## 测试

- 新增 `fileStoreReveal.test.ts`：竞态三场景（新文件刷新后命中并展开三层祖先 / 已在树中不做多余刷新 / 真不存在保持原回退）
- `fileReveal.test.ts` 补后缀兜底 + 裸文件名定位回归用例
- 全量 291 passed，tsc 零错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)