### PR TITLE
[codex] Fix TC-seven file panel and export issues

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4236,6 +4236,79 @@ async fn export_session_json(path: String, output_path: String) -> Result<(), St
     Ok(())
 }
 
+#[derive(Deserialize)]
+struct SessionZipItem {
+    path: String,
+    name: Option<String>,
+}
+
+fn sanitize_zip_segment(input: &str) -> String {
+    let cleaned: String = input
+        .chars()
+        .map(|ch| match ch {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            ch if ch.is_control() => '_',
+            ch => ch,
+        })
+        .collect();
+    let trimmed = cleaned.trim().trim_matches('.').trim();
+    if trimmed.is_empty() {
+        "session".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+#[tauri::command]
+async fn export_session_group_zip(
+    group_label: String,
+    sessions: Vec<SessionZipItem>,
+    output_path: String,
+) -> Result<(), String> {
+    use std::io::{Read, Write};
+    use zip::write::SimpleFileOptions;
+
+    if sessions.is_empty() {
+        return Err("No sessions to export".to_string());
+    }
+
+    let out = std::fs::File::create(&output_path)
+        .map_err(|e| format!("Failed to create zip: {}", e))?;
+    let mut zip = zip::ZipWriter::new(out);
+    let options = SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        .unix_permissions(0o644);
+    let folder = sanitize_zip_segment(&group_label);
+
+    zip.add_directory(format!("{}/", folder), options)
+        .map_err(|e| format!("Failed to create zip folder: {}", e))?;
+
+    for (idx, item) in sessions.iter().enumerate() {
+        let source_path = std::path::Path::new(&item.path);
+        let mut source = std::fs::File::open(source_path)
+            .map_err(|e| format!("Failed to open session {}: {}", item.path, e))?;
+        let fallback = source_path
+            .file_stem()
+            .and_then(|name| name.to_str())
+            .unwrap_or("session");
+        let base_name = sanitize_zip_segment(item.name.as_deref().unwrap_or(fallback));
+        let entry_name = format!("{}/{:02}_{}.jsonl", folder, idx + 1, base_name);
+
+        zip.start_file(entry_name, options)
+            .map_err(|e| format!("Failed to add zip entry: {}", e))?;
+        let mut buf = Vec::new();
+        source
+            .read_to_end(&mut buf)
+            .map_err(|e| format!("Failed to read session {}: {}", item.path, e))?;
+        zip.write_all(&buf)
+            .map_err(|e| format!("Failed to write zip entry: {}", e))?;
+    }
+
+    zip.finish()
+        .map_err(|e| format!("Failed to finish zip: {}", e))?;
+    Ok(())
+}
+
 /// List recent projects by scanning ~/.claude/projects/ directory names
 #[tauri::command]
 async fn list_recent_projects() -> Result<Vec<Value>, String> {
@@ -8111,6 +8184,7 @@ pub fn run() {
             share_to_wechat,
             export_session_markdown,
             export_session_json,
+            export_session_group_zip,
             list_recent_projects,
             watch_directory,
             unwatch_directory,

--- a/src/App.css
+++ b/src/App.css
@@ -27,11 +27,13 @@
   --color-border: #E5E5EA;
   --color-border-subtle: #EBEBF0;
   --color-border-focus: #333333;
+  --color-border-focus-soft: rgba(51, 51, 51, 0.28);
 
   --color-accent: #333333;
   --color-accent-light: #555555;
   --color-accent-hover: #1A1A1A;
   --color-accent-glow: rgba(0, 0, 0, 0.06);
+  --color-selection: rgba(51, 51, 51, 0.18);
   --color-success: #10b981;
   --color-error: #ef4444;
   --color-warning: #f59e0b;
@@ -90,11 +92,13 @@
   --color-border: #38383A;
   --color-border-subtle: #2C2C2E;
   --color-border-focus: #D0D0D0;
+  --color-border-focus-soft: rgba(208, 208, 208, 0.32);
 
   --color-accent: #D0D0D0;
   --color-accent-light: #E0E0E0;
   --color-accent-hover: #FFFFFF;
   --color-accent-glow: rgba(255, 255, 255, 0.08);
+  --color-selection: rgba(208, 208, 208, 0.22);
 
   --color-gradient-start: #D0D0D0;
   --color-gradient-mid: #E0E0E0;
@@ -129,11 +133,13 @@
 
   --color-text-secondary: #4E80F7;
   --color-border-focus: #4E80F7;
+  --color-border-focus-soft: rgba(78, 128, 247, 0.34);
 
   --color-accent: #4E80F7;
   --color-accent-light: #6B9AFF;
   --color-accent-hover: #3D6FE6;
   --color-accent-glow: rgba(78, 128, 247, 0.10);
+  --color-selection: rgba(78, 128, 247, 0.22);
 
   --color-gradient-start: #4E80F7;
   --color-gradient-mid: #5C8EFF;
@@ -155,11 +161,13 @@
 
   --color-text-secondary: #6B9AFF;
   --color-border-focus: #6B9AFF;
+  --color-border-focus-soft: rgba(107, 154, 255, 0.38);
 
   --color-accent: #6B9AFF;
   --color-accent-light: #8AB2FF;
   --color-accent-hover: #4E80F7;
   --color-accent-glow: rgba(107, 154, 255, 0.15);
+  --color-selection: rgba(107, 154, 255, 0.28);
 
   --color-gradient-start: #4E80F7;
   --color-gradient-mid: #5C8EFF;
@@ -183,11 +191,13 @@
 
   --color-text-secondary: #9169BF;
   --color-border-focus: #9169BF;
+  --color-border-focus-soft: rgba(145, 105, 191, 0.34);
 
   --color-accent: #9169BF;
   --color-accent-light: #A684CC;
   --color-accent-hover: #7A5AA3;
   --color-accent-glow: rgba(145, 105, 191, 0.10);
+  --color-selection: rgba(145, 105, 191, 0.22);
 
   --color-gradient-start: #9169BF;
   --color-gradient-mid: #9B77C6;
@@ -209,11 +219,13 @@
 
   --color-text-secondary: #A684CC;
   --color-border-focus: #A684CC;
+  --color-border-focus-soft: rgba(166, 132, 204, 0.38);
 
   --color-accent: #A684CC;
   --color-accent-light: #C0A0DC;
   --color-accent-hover: #9169BF;
   --color-accent-glow: rgba(166, 132, 204, 0.15);
+  --color-selection: rgba(166, 132, 204, 0.28);
 
   --color-gradient-start: #9169BF;
   --color-gradient-mid: #9B77C6;
@@ -237,11 +249,13 @@
 
   --color-text-secondary: #4CA85A;
   --color-border-focus: #57A64B;
+  --color-border-focus-soft: rgba(87, 166, 75, 0.34);
 
   --color-accent: #57A64B;
   --color-accent-light: #6DBF62;
   --color-accent-hover: #56AD63;
   --color-accent-glow: rgba(87, 166, 75, 0.10);
+  --color-selection: rgba(87, 166, 75, 0.22);
   --color-success: #57A64B;
 
   --color-gradient-start: #57A64B;
@@ -264,11 +278,13 @@
 
   --color-text-secondary: #6DBF62;
   --color-border-focus: #6DBF62;
+  --color-border-focus-soft: rgba(109, 191, 98, 0.38);
 
   --color-accent: #6DBF62;
   --color-accent-light: #97DEA2;
   --color-accent-hover: #57A64B;
   --color-accent-glow: rgba(109, 191, 98, 0.15);
+  --color-selection: rgba(109, 191, 98, 0.28);
 
   --color-gradient-start: #57A64B;
   --color-gradient-mid: #73C880;
@@ -315,6 +331,44 @@
 
 .dark .bg-accent {
   box-shadow: 0 1px 6px var(--color-accent-glow);
+}
+
+.border-focus-soft {
+  border-color: var(--color-border-focus-soft);
+}
+
+.file-preview-markdown ::selection {
+  background: var(--color-selection);
+  color: inherit;
+}
+
+.file-preview-markdown .prose :where(p, h1, h2, h3, h4, h5, h6, blockquote) {
+  width: fit-content;
+  max-width: 100%;
+}
+
+.file-preview-markdown mark[class^="hltr-"],
+.file-preview-markdown mark[class*=" hltr-"] {
+  border-radius: 0.22em;
+  padding: 0.05em 0.14em;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
+.file-preview-markdown .hltr-red {
+  background: rgba(239, 68, 68, 0.24);
+}
+
+.file-preview-markdown .hltr-yellow {
+  background: rgba(245, 158, 11, 0.28);
+}
+
+.file-preview-markdown .hltr-green {
+  background: rgba(16, 185, 129, 0.24);
+}
+
+.file-preview-markdown .hltr-purple {
+  background: rgba(145, 105, 191, 0.26);
 }
 
 /* ================================================================

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -471,7 +471,7 @@ export function ChatPanel() {
     <div className="flex flex-col h-full">
       {/* Top Bar — with extra top padding for macOS traffic lights */}
       <div
-        className="flex items-center h-[68px] pt-[20px] px-5 border-b border-border-subtle
+        className="flex items-center w-full h-[68px] pt-[20px] px-5 border-b border-border-subtle
         flex-shrink-0 bg-bg-chat cursor-default">
         {/* Show sidebar toggle when sidebar is not visible:
             either user closed it, or it's hidden by file preview mode */}
@@ -486,7 +486,7 @@ export function ChatPanel() {
           </button>
         )}
         {/* Left: model name + project hint */}
-        <div className="flex items-center gap-3 pointer-events-none">
+        <div className="flex items-center gap-3 pointer-events-none min-w-0 flex-shrink-0">
           {sessionMeta.model && (
             <span className="text-sm font-medium text-text-muted">
               {getModelDisplayName(sessionMeta.model)}
@@ -501,7 +501,7 @@ export function ChatPanel() {
         </div>
 
         {/* Integrated status: Agent + API route — left-aligned with color dots */}
-        <div className="relative flex items-center gap-3 ml-3">
+        <div className="relative flex items-center gap-3 ml-3 min-w-0">
           {/* Agent status — clickable dot + label → opens AgentPanel */}
           <button onClick={toggleAgentPanel}
             className={`flex items-center gap-1.5 px-1.5 py-0.5 rounded-lg
@@ -554,18 +554,19 @@ export function ChatPanel() {
         </div>
 
         {/* Spacer + right-side actions */}
-        <div className="ml-auto flex items-center" />
-        <UpdateButton />
-        <ExportMenu sessionPath={currentSessionPath} />
-        <button onClick={toggleSecondaryPanel}
-          className="p-1.5 rounded-lg hover:bg-bg-tertiary text-text-tertiary
-            transition-smooth" title={t('chat.toggleFiles')}>
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"
-            stroke="currentColor" strokeWidth="1.5">
-            <rect x="1" y="2" width="14" height="12" rx="2" />
-            <path d="M10 2v12" />
-          </svg>
-        </button>
+        <div className="ml-auto flex items-center gap-1 flex-shrink-0">
+          <UpdateButton />
+          <ExportMenu sessionPath={currentSessionPath} />
+          <button onClick={toggleSecondaryPanel}
+            className="p-1.5 rounded-lg hover:bg-bg-tertiary text-text-tertiary
+              transition-smooth" title={t('chat.toggleFiles')}>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"
+              stroke="currentColor" strokeWidth="1.5">
+              <rect x="1" y="2" width="14" height="12" rx="2" />
+              <path d="M10 2v12" />
+            </svg>
+          </button>
+        </div>
       </div>
 
       <div className="flex flex-1 min-h-0 relative">

--- a/src/components/chat/InputBar.tsx
+++ b/src/components/chat/InputBar.tsx
@@ -1515,7 +1515,7 @@ export function InputBar() {
           />
           <div
             className={`flex items-center gap-2 bg-bg-input border rounded-2xl px-4 py-2.5
-              focus-within:border-border-focus focus-within:shadow-glow
+              focus-within:border-focus-soft focus-within:shadow-glow
               transition-smooth group/input
               ${isDragging
                 ? 'border-accent bg-accent/5 shadow-glow'

--- a/src/components/conversations/ConversationList.tsx
+++ b/src/components/conversations/ConversationList.tsx
@@ -506,6 +506,32 @@ export function ConversationList() {
     }
   }, []);
 
+  const handleExportGroupZip = useCallback(async (groupId: string) => {
+    const group = useGroupStore.getState().groups.find((g) => g.id === groupId);
+    if (!group) return;
+    const allSessions = useSessionStore.getState().sessions;
+    const groupSessions = group.sessionIds
+      .map((id) => allSessions.find((s) => s.id === id))
+      .filter((s): s is SessionListItem => !!s?.path);
+    if (groupSessions.length === 0) return;
+
+    const safeLabel = group.label.replace(/[\\/:*?"<>|]/g, '_').trim() || 'sessions';
+    const outputPath = await save({
+      defaultPath: `${safeLabel}.zip`,
+      filters: [{ name: 'Zip', extensions: ['zip'] }],
+    });
+    if (outputPath) {
+      bridge.exportSessionGroupZip(
+        group.label,
+        groupSessions.map((session) => ({
+          path: session.path,
+          name: customPreviews[session.id] || session.preview || session.id,
+        })),
+        outputPath,
+      ).catch(() => {});
+    }
+  }, [customPreviews]);
+
   const handleNewSessionInProject = useCallback((projectKey: string) => {
     const suffix = projectKey.replace(/^~/, '');
     const allSessions = useSessionStore.getState().sessions;
@@ -681,7 +707,7 @@ export function ConversationList() {
         <div className="flex items-center gap-2">
           <div className="flex-1 min-w-0 flex items-center gap-2 px-3 py-2 rounded-xl
             bg-bg-secondary border border-border-subtle
-            focus-within:border-border-focus transition-smooth">
+            focus-within:border-focus-soft transition-smooth">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none"
               stroke="currentColor" strokeWidth="1.5"
               className="text-text-tertiary flex-shrink-0">
@@ -902,6 +928,7 @@ export function ConversationList() {
           y={groupMenu.y}
           groupId={groupMenu.groupId}
           onRename={(id) => setRenamingGroupId(id)}
+          onExport={handleExportGroupZip}
           onDelete={handleDeleteGroup}
           onClose={() => setGroupMenu(null)}
         />

--- a/src/components/conversations/SessionContextMenu.tsx
+++ b/src/components/conversations/SessionContextMenu.tsx
@@ -293,6 +293,7 @@ interface GroupContextMenuProps {
   y: number;
   groupId: string;
   onRename: (groupId: string) => void;
+  onExport?: (groupId: string) => void;
   onDelete: (groupId: string) => void;
   onClose: () => void;
 }
@@ -302,6 +303,7 @@ export function GroupContextMenu({
   y,
   groupId,
   onRename,
+  onExport,
   onDelete,
   onClose,
 }: GroupContextMenuProps) {
@@ -336,6 +338,17 @@ export function GroupContextMenu({
         </svg>
         重命名任务组
       </button>
+
+      {onExport && (
+        <button onClick={() => { onClose(); onExport(groupId); }} className={itemCls}>
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="none"
+            stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+            <path d="M4 14h8M8 2v8M5 7l3 3 3-3" />
+            <path d="M3 4h2M11 4h2" />
+          </svg>
+          导出整组 Session
+        </button>
+      )}
 
       <div className="my-1 border-t border-border-subtle" />
 

--- a/src/components/files/FileExplorer.tsx
+++ b/src/components/files/FileExplorer.tsx
@@ -252,7 +252,7 @@ function SearchResultItem({
     <button
       onClick={() => { if (!node.is_dir) selectFile(node.path); }}
       onContextMenu={(e) => { e.preventDefault(); onContextMenu(e, node.path, node.is_dir); }}
-      className={`w-full flex items-center gap-1.5 py-1.5 px-3 rounded-md
+      className={`w-full flex items-center gap-1.5 py-1.5 px-3 rounded-xl
         text-left text-[13px] transition-smooth group
         ${isSelected
           ? 'bg-accent/10 text-accent'
@@ -399,7 +399,7 @@ function TreeNode({
           onContextMenu(e, node.path, node.is_dir);
         }}
         {...(node.is_dir ? { 'data-dir-path': node.path } : {})}
-        className={`w-full flex items-center gap-1.5 py-1.5 px-2 rounded-md
+        className={`w-full flex items-center gap-1.5 py-1.5 px-2 rounded-xl
           text-left text-[13px] transition-smooth group
           ${isActive
             ? 'bg-accent/10 text-accent'
@@ -434,7 +434,7 @@ function TreeNode({
             onBlur={onRenameCancel}
             onClick={(e) => e.stopPropagation()}
             className="flex-1 min-w-0 text-[13px] bg-bg-input border border-border-focus
-              rounded-lg px-1.5 py-0.5 outline-none text-text-primary"
+              rounded-xl px-1.5 py-0.5 outline-none text-text-primary"
           />
         ) : (
           <span className="truncate">{node.name}</span>
@@ -465,7 +465,7 @@ function TreeNode({
                 onBlur={onCreateCancel}
                 placeholder={creatingIn.type === 'folder' ? 'folder name' : 'file name'}
                 className="flex-1 min-w-0 text-[13px] bg-bg-input border border-border-focus
-                  rounded-lg px-1.5 py-0.5 outline-none text-text-primary"
+                  rounded-xl px-1.5 py-0.5 outline-none text-text-primary"
               />
             </div>
           )}
@@ -740,7 +740,7 @@ export function FileExplorer() {
                     onBlur={handleCreateCancel}
                     placeholder={creatingIn.type === 'file' ? t('files.newFile') : t('files.newFolder')}
                     className="flex-1 min-w-0 text-[13px] bg-bg-input border border-border-focus
-                      rounded-lg px-1.5 py-0.5 outline-none text-text-primary
+                      rounded-xl px-1.5 py-0.5 outline-none text-text-primary
                       placeholder:text-text-tertiary"
                   />
                 </div>
@@ -789,9 +789,10 @@ export function FileExplorer() {
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder={t('files.search')}
             className="w-full pl-7 pr-7 py-1.5 text-[13px] bg-transparent
-              rounded-lg text-text-primary
+              border border-transparent rounded-xl text-text-primary
               placeholder:text-text-tertiary outline-none
               hover:bg-bg-secondary focus:bg-bg-secondary
+              focus:border-focus-soft
               transition-smooth"
           />
           {searchQuery && (

--- a/src/components/files/FilePreview.tsx
+++ b/src/components/files/FilePreview.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback, useEffect, useRef } from 'react';
+import { useMemo, useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import DOMPurify from 'dompurify';
 import CodeMirror from '@uiw/react-codemirror';
@@ -29,6 +29,7 @@ import { MarkdownRenderer } from '../shared/MarkdownRenderer';
 import { FileIcon } from '../shared/FileIcon';
 import { tokenicodeTheme, tokenicodeHighlight } from '../../lib/codemirror-theme';
 import { useT } from '../../lib/i18n';
+import { showToast } from '../shared/Toast';
 
 /* ================================================================
    Helpers
@@ -100,6 +101,147 @@ const BINARY_EXTS = new Set(['zip', 'tar', 'gz', 'rar', '7z', 'exe', 'dmg', 'pkg
   'woff', 'woff2', 'ttf', 'otf', 'eot',
   'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'db', 'sqlite']);
 
+type HighlightColor = 'red' | 'yellow' | 'green' | 'purple';
+
+const HIGHLIGHT_OPTIONS: Array<{ id: HighlightColor; label: string; className: string }> = [
+  { id: 'red', label: '红色', className: 'bg-red-500' },
+  { id: 'yellow', label: '黄色', className: 'bg-amber-400' },
+  { id: 'green', label: '绿色', className: 'bg-emerald-500' },
+  { id: 'purple', label: '紫色', className: 'bg-purple-500' },
+];
+
+interface HighlightMenuState {
+  x: number;
+  y: number;
+  text: string;
+  existing: boolean;
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function replaceExistingHighlight(
+  content: string,
+  text: string,
+  color: HighlightColor | null,
+): string | null {
+  const markRe = /<mark\s+class=["']hltr-(red|yellow|green|purple)["']>([\s\S]*?)<\/mark>/g;
+  let match: RegExpExecArray | null;
+  while ((match = markRe.exec(content))) {
+    if (match[2] !== text) continue;
+    const next = color ? `<mark class="hltr-${color}">${match[2]}</mark>` : match[2];
+    return content.slice(0, match.index) + next + content.slice(match.index + match[0].length);
+  }
+  return null;
+}
+
+function applyHighlightToContent(
+  content: string,
+  text: string,
+  color: HighlightColor | null,
+  existing: boolean,
+): string | null {
+  const selected = text.trim();
+  if (!selected) return null;
+
+  if (existing) {
+    const replaced = replaceExistingHighlight(content, selected, color);
+    if (replaced) return replaced;
+  }
+
+  if (!color) return null;
+  const markRe = new RegExp(
+    `<mark\\s+class=["']hltr-(red|yellow|green|purple)["']>${escapeRegExp(selected)}</mark>`,
+  );
+  if (markRe.test(content)) {
+    return content.replace(markRe, `<mark class="hltr-${color}">${selected}</mark>`);
+  }
+
+  const index = content.indexOf(selected);
+  if (index === -1) return null;
+  return `${content.slice(0, index)}<mark class="hltr-${color}">${selected}</mark>${content.slice(index + selected.length)}`;
+}
+
+function HighlightMenu({
+  menu,
+  onApply,
+  onRemove,
+  onClose,
+}: {
+  menu: HighlightMenuState;
+  onApply: (color: HighlightColor) => void;
+  onRemove: () => void;
+  onClose: () => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ x: menu.x, y: menu.y });
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const rect = ref.current.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    let x = menu.x;
+    let y = menu.y;
+    if (x + rect.width > vw - 8) x = vw - rect.width - 8;
+    if (y + rect.height > vh - 8) y = vh - rect.height - 8;
+    setPos({ x: Math.max(8, x), y: Math.max(8, y) });
+  }, [menu.x, menu.y]);
+
+  useEffect(() => {
+    const handleDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('mousedown', handleDown);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleDown);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      ref={ref}
+      className="fixed z-[10000] min-w-[156px] py-1.5 rounded-xl border border-border-subtle
+        bg-bg-card shadow-xl animate-fade-in"
+      style={{ left: pos.x, top: pos.y }}
+    >
+      <div className="px-3 pb-1.5 text-[10px] text-text-tertiary select-none">
+        高亮
+      </div>
+      {HIGHLIGHT_OPTIONS.map((option) => (
+        <button
+          key={option.id}
+          onClick={() => onApply(option.id)}
+          className="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs
+            text-text-primary hover:bg-bg-secondary transition-smooth"
+        >
+          <span className={`w-3 h-3 rounded-full ${option.className}`} />
+          {option.label}
+        </button>
+      ))}
+      {menu.existing && (
+        <>
+          <div className="my-1 border-t border-border-subtle" />
+          <button
+            onClick={onRemove}
+            className="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs
+              text-text-muted hover:text-text-primary hover:bg-bg-secondary transition-smooth"
+          >
+            取消高亮
+          </button>
+        </>
+      )}
+    </div>,
+    document.body,
+  );
+}
+
 /* ================================================================
    FilePreview component
    ================================================================ */
@@ -122,6 +264,8 @@ export function FilePreview() {
   const confirmDiscard = useFileStore((s) => s.confirmDiscard);
   const confirmSaveAndSwitch = useFileStore((s) => s.confirmSaveAndSwitch);
   const cancelNavigation = useFileStore((s) => s.cancelNavigation);
+  const [highlightMenu, setHighlightMenu] = useState<HighlightMenuState | null>(null);
+  const markdownPreviewRef = useRef<HTMLDivElement>(null);
 
   // Auto-refresh preview when the selected file is modified externally
   const reloadRef = useRef(reloadContent);
@@ -163,6 +307,57 @@ export function FilePreview() {
       if (isDirty) saveFile();
     }
   }, [isDirty, saveFile]);
+
+  const handleMarkdownContextMenu = useCallback((e: React.MouseEvent) => {
+    if (!isMarkdown || previewMode !== 'preview') return;
+    const container = markdownPreviewRef.current;
+    if (!container) return;
+
+    const target = e.target as HTMLElement;
+    const existingMark = target.closest('mark[class^="hltr-"], mark[class*=" hltr-"]');
+    const selection = window.getSelection();
+    const selectedText = selection
+      && !selection.isCollapsed
+      && selection.anchorNode
+      && selection.focusNode
+      && container.contains(selection.anchorNode)
+      && container.contains(selection.focusNode)
+      ? selection.toString().trim()
+      : '';
+    const text = existingMark?.textContent?.trim() || selectedText;
+    if (!text) return;
+
+    e.preventDefault();
+    setHighlightMenu({
+      x: e.clientX,
+      y: e.clientY,
+      text,
+      existing: !!existingMark,
+    });
+  }, [isMarkdown, previewMode]);
+
+  const updateHighlight = useCallback(async (color: HighlightColor | null) => {
+    if (!selectedFile || fileContent === null || !highlightMenu) return;
+    const next = applyHighlightToContent(
+      fileContent,
+      highlightMenu.text,
+      color,
+      highlightMenu.existing,
+    );
+    if (!next || next === fileContent) {
+      showToast('未能在源文件中定位这段文字', 'error');
+      setHighlightMenu(null);
+      return;
+    }
+    try {
+      await bridge.writeFileContent(selectedFile, next);
+      await reloadContent();
+    } catch (err) {
+      showToast(`高亮写入失败: ${err}`, 'error');
+    } finally {
+      setHighlightMenu(null);
+    }
+  }, [selectedFile, fileContent, highlightMenu, reloadContent]);
 
   /* Mode tabs for the header */
   const modeTabs = useMemo(() => {
@@ -411,7 +606,11 @@ export function FilePreview() {
           </div>
         ) : previewMode === 'preview' && isMarkdown && fileContent !== null ? (
           /* Markdown preview: rendered */
-          <div className="overflow-auto h-full p-4">
+          <div
+            ref={markdownPreviewRef}
+            onContextMenu={handleMarkdownContextMenu}
+            className="overflow-auto h-full p-4 file-preview-markdown"
+          >
             <div className="text-sm leading-relaxed selectable max-w-3xl mx-auto">
               {(() => {
                 // Extract YAML frontmatter if present
@@ -499,6 +698,14 @@ export function FilePreview() {
           </div>
         </div>,
         document.body,
+      )}
+      {highlightMenu && (
+        <HighlightMenu
+          menu={highlightMenu}
+          onApply={(color) => updateHighlight(color)}
+          onRemove={() => updateHighlight(null)}
+          onClose={() => setHighlightMenu(null)}
+        />
       )}
     </div>
   );

--- a/src/components/layout/SecondaryPanel.tsx
+++ b/src/components/layout/SecondaryPanel.tsx
@@ -1,4 +1,5 @@
 import { useSettingsStore, SecondaryPanelTab } from '../../stores/settingsStore';
+import { useFileStore } from '../../stores/fileStore';
 import { FileExplorer } from '../files/FileExplorer';
 import { SkillsPanel } from '../skills/SkillsPanel';
 import { useT } from '../../lib/i18n';
@@ -26,6 +27,8 @@ export function SecondaryPanel() {
   const activeTab = useSettingsStore((s) => s.secondaryPanelTab);
   const setTab = useSettingsStore((s) => s.setSecondaryTab);
   const togglePanel = useSettingsStore((s) => s.toggleSecondaryPanel);
+  const refreshTree = useFileStore((s) => s.refreshTree);
+  const clearChangedFiles = useFileStore((s) => s.clearChangedFiles);
 
   // Window dragging handled via CSS -webkit-app-region: drag on the top strip
 
@@ -40,6 +43,11 @@ export function SecondaryPanel() {
             <button
               key={tab.id}
               onClick={() => setTab(tab.id)}
+              onDoubleClick={() => {
+                if (tab.id !== 'files') return;
+                refreshTree();
+                clearChangedFiles();
+              }}
               className={`px-2.5 py-1.5 rounded-lg text-[13px] font-medium
                 transition-smooth flex items-center gap-1.5 whitespace-nowrap flex-shrink-0
                 ${activeTab === tab.id

--- a/src/components/shared/MarkdownRenderer.tsx
+++ b/src/components/shared/MarkdownRenderer.tsx
@@ -262,6 +262,7 @@ interface Props {
 // Sanitize schema: GitHub defaults + className on all elements (needed for highlight.js)
 const SANITIZE_SCHEMA = {
   ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames || []), 'mark'],
   attributes: {
     ...defaultSchema.attributes,
     '*': [...(defaultSchema.attributes?.['*'] || []), 'className'],

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -52,6 +52,11 @@ export interface SessionListItem {
   cliResumeId: string | null;
 }
 
+export interface SessionZipItem {
+  path: string;
+  name?: string;
+}
+
 export interface ContentSearchResult {
   session_id: string;
   snippet: string;
@@ -292,6 +297,9 @@ export const bridge = {
 
   exportSessionJson: (path: string, outputPath: string) =>
     invoke<void>('export_session_json', { path, outputPath }),
+
+  exportSessionGroupZip: (groupLabel: string, sessions: SessionZipItem[], outputPath: string) =>
+    invoke<void>('export_session_group_zip', { groupLabel, sessions, outputPath }),
 
   listRecentProjects: () =>
     invoke<RecentProject[]>('list_recent_projects'),


### PR DESCRIPTION
## Summary

- Fixes the chat top bar distribution on wide screens so left status and right actions use the full available width.
- Softens focus borders for the main input, conversation search, and file search fields.
- Adds double-click refresh/read behavior to the Files tab, clears file change badges, and aligns file tree item hover/selected styling with session cards.
- Adds task-group export as a zip of session JSONL files.
- Adds theme-aware Markdown preview selection styling and a right-click 4-color highlight menu that writes `<mark class="hltr-*">` tags back to the source Markdown file.

## Issues

Addresses #121, #122, #123, #124, #125, #126, #127.

## Validation

- `./node_modules/.bin/tsc && ./node_modules/.bin/vite build`
- `cargo check` in `src-tauri/`

## Notes

This is opened as a draft for UI review because several changes are visual and interaction-facing.
